### PR TITLE
Add sub categories

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,11 +36,11 @@ SwiftyUserDefaults infers the right type when setting values.
 Defaults["category"]["launchCount"].int         // same as Defaults["category.launchCount”].int
 Defaults["category"]["launchCount"] = 0        // same as Defaults["category.launchCount"] = 0
 
-let categoryDefault = Defaults["category"]
+let categoryDefault = Defaults["category"] as NSUserDefaults.Proxy
 categoryDefault["launchCount"].int         // same as Defaults["category.launchCount”].int
 categoryDefault["launchCount"] = 0        // same as Defaults["category.launchCount"] = 0
 
-let subDefault = categoryDefault["sub"]
+let subDefault = categoryDefault["sub"] as NSUserDefaults.Proxy
 subDefault["launchCount"].int         // same as Defaults["category.sub.launchCount”].int
 subDefault["launchCount"] = 0        // same as Defaults["category.sub.launchCount"] = 0
 ```

--- a/README.md
+++ b/README.md
@@ -30,6 +30,23 @@ Defaults["launchCount"] = 0
 
 SwiftyUserDefaults infers the right type when setting values.
 
+### Sub category
+
+```swift
+Defaults["category"]["launchCount"].int         // same as Defaults["category.launchCount”].int
+Defaults["category"]["launchCount"] = 0        // same as Defaults["category.launchCount"] = 0
+
+let categoryDefault = Defaults["category"]
+categoryDefault["launchCount"].int         // same as Defaults["category.launchCount”].int
+categoryDefault["launchCount"] = 0        // same as Defaults["category.launchCount"] = 0
+
+let subDefault = categoryDefault["sub"]
+subDefault["launchCount"].int         // same as Defaults["category.sub.launchCount”].int
+subDefault["launchCount"] = 0        // same as Defaults["category.sub.launchCount"] = 0
+```
+
+Keys are concatenated using separator `DefaultsKeySeparator`
+
 ### Optional assignment
 
 ```swift

--- a/Src/SwiftyUserDefaults.swift
+++ b/Src/SwiftyUserDefaults.swift
@@ -34,6 +34,36 @@ public extension NSUserDefaults {
             self.key = key
         }
         
+        /// Returns getter proxy for `key`
+        
+        public subscript(key: String) -> Proxy {
+            return Proxy(self.defaults, self.key + DefaultsKeySeparator + key)
+        }
+        
+        /// Sets value for `key`
+        
+        public subscript(key: String) -> Any? {
+            get {
+                return self[key]
+            }
+            set {
+                let k = self.key + DefaultsKeySeparator + key
+                if let v = newValue as? Int {
+                    defaults.setInteger(v, forKey: k)
+                } else if let v = newValue as? Double {
+                    defaults.setDouble(v, forKey: k)
+                } else if let v = newValue as? Bool {
+                    defaults.setBool(v, forKey: k)
+                } else if let v = newValue as? NSObject {
+                    defaults.setObject(v, forKey: k)
+                } else if newValue == nil {
+                    defaults.removeObjectForKey(k)
+                } else {
+                    assertionFailure("Invalid value type")
+                }
+            }
+        }
+
         // MARK: Getters
         
         public var object: NSObject? {
@@ -157,3 +187,4 @@ public postfix func ++ (proxy: NSUserDefaults.Proxy) {
 /// Global shortcut for NSUserDefaults.standardUserDefaults()
 
 public let Defaults = NSUserDefaults.standardUserDefaults()
+public var DefaultsKeySeparator = "."

--- a/Tests/SwiftyUserDefaultsTests/main.swift
+++ b/Tests/SwiftyUserDefaultsTests/main.swift
@@ -47,6 +47,19 @@ assert(Defaults["bool1"].int == 0)
 assert(Defaults["bool1"].double == 0.0)
 assert(Defaults["bool1"].bool == false)
 
+Defaults["proxy"]["int1"] = 100
+assert(Defaults["proxy"]["int1"].string == "100")
+assert(Defaults["proxy"]["int1"].int == 100)
+assert(Defaults["proxy"]["int1"].double == 100)
+assert(Defaults["proxy"]["int1"].bool == true)
+assert(Defaults["proxy"]["int1"].int == Defaults["proxy" + DefaultsKeySeparator + "int1"].int)
+
+Defaults["proxy"]["sub"]["double1"] = 3.14
+assert(Defaults["proxy"]["sub"]["double1"].string == "3.14")
+assert(Defaults["proxy"]["sub"]["double1"].int == 3)
+assert(Defaults["proxy"]["sub"]["double1"].double == 3.14)
+assert(Defaults["proxy"]["sub"]["double1"].bool == true)
+
 // Object types
 let data = "foo".dataUsingEncoding(NSUTF8StringEncoding, allowLossyConversion: false)!
 Defaults["data1"] = data

--- a/Tests/SwiftyUserDefaultsTests/main.swift
+++ b/Tests/SwiftyUserDefaultsTests/main.swift
@@ -59,6 +59,13 @@ assert(Defaults["proxy"]["sub"]["double1"].string == "3.14")
 assert(Defaults["proxy"]["sub"]["double1"].int == 3)
 assert(Defaults["proxy"]["sub"]["double1"].double == 3.14)
 assert(Defaults["proxy"]["sub"]["double1"].bool == true)
+let proxyDefaults = Defaults["proxy"] as NSUserDefaults.Proxy
+let subDefaults : NSUserDefaults.Proxy = proxyDefaults["sub"]
+assert(subDefaults["double1"].string == "3.14")
+assert(subDefaults["double1"].int == 3)
+assert(subDefaults["double1"].double == 3.14)
+assert(subDefaults["double1"].bool == true)
+
 
 // Object types
 let data = "foo".dataUsingEncoding(NSUTF8StringEncoding, allowLossyConversion: false)!


### PR DESCRIPTION
Access to user defaults with keys that contain the separator '.'
Allow to prefix all the key with one or more (ex: 'com.apple', 'io.radex' )
```swift
let radexDefault : NSUserDefaults.Proxy = Defaults["io.radex"] // or Defaults["io"]["radex"]
radexDefault["launchCount"].int         // same as Defaults["io.radex.launchCount”].int
radexDefault["launchCount"] = 0 
```