### PR TITLE
Add URL support. Add Unit tests.

### DIFF
--- a/SwiftyUserDefaults/SwiftyUserDefaults.swift
+++ b/SwiftyUserDefaults/SwiftyUserDefaults.swift
@@ -76,6 +76,10 @@ public extension NSUserDefaults {
             return number?.boolValue
         }
         
+        public var URL: NSURL? {
+            return defaults.URLForKey(key)
+        }
+        
         // MARK: Non-Optional Getters
         
         public var stringValue: String {
@@ -130,6 +134,8 @@ public extension NSUserDefaults {
                 setDouble(v, forKey: key)
             } else if let v = newValue as? Bool {
                 setBool(v, forKey: key)
+            } else if let v = newValue as? NSURL {
+                setURL(v, forKey: key)
             } else if let v = newValue as? NSObject {
                 setObject(v, forKey: key)
             } else if newValue == nil {
@@ -162,7 +168,7 @@ infix operator ?= {
 /// Note: This isn't the same as `Defaults.registerDefaults`. This method saves the new value to disk, whereas `registerDefaults` only modifies the defaults in memory.
 /// Note: If key already exists, the expression after ?= isn't evaluated
 
-public func ?= (proxy: NSUserDefaults.Proxy, @autoclosure expr: () -> Any) {
+public func ?= (proxy: NSUserDefaults.Proxy, @autoclosure expr: () -> Any?) {
     if !proxy.defaults.hasKey(proxy.key) {
         proxy.defaults[proxy.key] = expr()
     }

--- a/SwiftyUserDefaultsTests/SwiftyUserDefaultsTests.swift
+++ b/SwiftyUserDefaultsTests/SwiftyUserDefaultsTests.swift
@@ -168,4 +168,34 @@ class SwiftyUserDefaultsTests: XCTestCase {
         Defaults[key] = dict
         XCTAssertEqual(Defaults[key].dictionary!, dict)
     }
+    
+    func testURL() {
+        // set and read
+        let key = "url"
+        Defaults[key] = NSURL(string: "https://github.com")
+        XCTAssertEqual(Defaults[key].URL!, NSURL(string: "https://github.com")!)
+        XCTAssertNil(Defaults[key].string)
+        XCTAssertNil(Defaults[key].int)
+        XCTAssertNil(Defaults[key].double)
+        XCTAssertNil(Defaults[key].bool)
+        
+        // existance
+        XCTAssertTrue(Defaults.hasKey(key))
+        
+        // ?=
+        Defaults[key] ?= NSURL(string: "https://google.com")
+        XCTAssertEqual(Defaults[key].URL!, NSURL(string: "https://github.com")!)
+        
+        let key2 = "url2"
+        Defaults[key2] ?= NSURL(string: "https://google.com")
+        XCTAssertEqual(Defaults[key2].URL!, NSURL(string: "https://google.com")!)
+        Defaults[key2] ?= NSURL(string: "https://facebook.com")
+        XCTAssertEqual(Defaults[key2].URL!, NSURL(string: "https://google.com")!)
+        
+        // removing
+        Defaults.remove(key)
+        XCTAssertFalse(Defaults.hasKey(key))
+        Defaults[key2] = nil
+        XCTAssertFalse(Defaults.hasKey(key2))
+    }
 }


### PR DESCRIPTION
Assigning a URL to Defaults will cause NSInvalidArgumentException.
```swift
Defaults["url"] = NSURL(string: "https://google.com")
```
Error:
> caught "NSInvalidArgumentException", "Attempt to insert non-property list object https://google.com for key url"

Also, for the ?= operation, if the expr is optional, it will not be correctly converted, and assertionFailure("Invalid value type") will be excuted. 
```swift
let string: String? = "abc"
Defaults["string"] ?= string
```
Change expr's type to Any? will solve that problem.
