### PR TITLE
Fixes UnitTest on iOS

### DIFF
--- a/SwiftyUserDefaultsTests/TestHelper.swift
+++ b/SwiftyUserDefaultsTests/TestHelper.swift
@@ -1,4 +1,10 @@
-import Cocoa
+#if os(iOS)
+    import UIKit
+    typealias NSColor = UIColor
+#elseif os(OSX)
+    import Cocoa
+#endif
+
 import SwiftyUserDefaults
 
 extension NSUserDefaults {


### PR DESCRIPTION
TestHelper.swift is in the iOS Target and the OS X Target. The file imports Cocoa, which is not available on iOS. To fix the resulting compiler issue I changed the implementation to import UIKit on iOS and Cocoa on OS X.