### PR TITLE
Add statically-defined default values WIP

### DIFF
--- a/SwiftyUserDefaults/SwiftyUserDefaults.swift
+++ b/SwiftyUserDefaults/SwiftyUserDefaults.swift
@@ -171,12 +171,25 @@ public class DefaultsKeys {
 /// Base class for static user defaults keys. Specialize with value type type
 /// and pass key name to the initializer to create a key.
 
+private protocol OptionalType {}
+extension Optional: OptionalType {}
+
 public class DefaultsKey<ValueType>: DefaultsKeys {
     // TODO: Can we use protocols to ensure ValueType is a compatible type?
     public let _key: String
     public let _default: ValueType?
     
-    public init(_ key: String, _ defaultValue: ValueType? = nil) {
+    public convenience init(_ key: String) {
+        self.init(key: key, defaultValue: nil)
+    }
+    
+    public convenience init(_ key: String, _ defaultValue: ValueType) {
+        precondition(!(defaultValue is OptionalType), "A default cannot be specified for an optional value type.")
+        
+        self.init(key: key, defaultValue: defaultValue)
+    }
+    
+    private init(key: String, defaultValue: ValueType?) {
         self._key = key
         self._default = defaultValue
     }

--- a/SwiftyUserDefaults/SwiftyUserDefaults.swift
+++ b/SwiftyUserDefaults/SwiftyUserDefaults.swift
@@ -174,9 +174,11 @@ public class DefaultsKeys {
 public class DefaultsKey<ValueType>: DefaultsKeys {
     // TODO: Can we use protocols to ensure ValueType is a compatible type?
     public let _key: String
+    public let _default: ValueType?
     
-    public init(_ key: String) {
+    public init(_ key: String, _ defaultValue: ValueType? = nil) {
         self._key = key
+        self._default = defaultValue
     }
 }
 
@@ -211,7 +213,7 @@ extension NSUserDefaults {
     }
     
     public subscript(key: DefaultsKey<String>) -> String {
-        get { return stringForKey(key._key) ?? "" }
+        get { return stringForKey(key._key) ?? key._default ?? "" }
         set { set(key, newValue) }
     }
     public subscript(key: DefaultsKey<NSString?>) -> NSString? {
@@ -220,7 +222,7 @@ extension NSUserDefaults {
     }
     
     public subscript(key: DefaultsKey<NSString>) -> NSString {
-        get { return stringForKey(key._key) ?? "" }
+        get { return stringForKey(key._key) ?? key._default ?? "" }
         set { set(key, newValue) }
     }
     
@@ -230,7 +232,7 @@ extension NSUserDefaults {
     }
     
     public subscript(key: DefaultsKey<Int>) -> Int {
-        get { return numberForKey(key._key)?.integerValue ?? 0 }
+        get { return numberForKey(key._key)?.integerValue ?? key._default ?? 0 }
         set { set(key, newValue) }
     }
     
@@ -240,7 +242,7 @@ extension NSUserDefaults {
     }
     
     public subscript(key: DefaultsKey<Double>) -> Double {
-        get { return numberForKey(key._key)?.doubleValue ?? 0.0 }
+        get { return numberForKey(key._key)?.doubleValue ?? key._default ?? 0.0 }
         set { set(key, newValue) }
     }
     
@@ -250,7 +252,7 @@ extension NSUserDefaults {
     }
     
     public subscript(key: DefaultsKey<Bool>) -> Bool {
-        get { return numberForKey(key._key)?.boolValue ?? false }
+        get { return numberForKey(key._key)?.boolValue ?? key._default ?? false }
         set { set(key, newValue) }
     }
     
@@ -270,7 +272,7 @@ extension NSUserDefaults {
     }
     
     public subscript(key: DefaultsKey<NSData>) -> NSData {
-        get { return dataForKey(key._key) ?? NSData() }
+        get { return dataForKey(key._key) ?? key._default ?? NSData() }
         set { set(key, newValue) }
     }
     
@@ -292,7 +294,7 @@ extension NSUserDefaults {
     }
     
     public subscript(key: DefaultsKey<[String: AnyObject]>) -> [String: AnyObject] {
-        get { return dictionaryForKey(key._key) ?? [:] }
+        get { return dictionaryForKey(key._key) ?? key._default ?? [:] }
         set { set(key, newValue) }
     }
     
@@ -302,7 +304,7 @@ extension NSUserDefaults {
     }
     
     public subscript(key: DefaultsKey<NSDictionary>) -> NSDictionary {
-        get { return dictionaryForKey(key._key) ?? [:] }
+        get { return dictionaryForKey(key._key) ?? key._default ?? [:] }
         set { set(key, newValue) }
     }
 }
@@ -316,7 +318,7 @@ extension NSUserDefaults {
     }
     
     public subscript(key: DefaultsKey<NSArray>) -> NSArray {
-        get { return arrayForKey(key._key) ?? [] }
+        get { return arrayForKey(key._key) ?? key._default ?? [] }
         set { set(key, newValue) }
     }
 
@@ -326,7 +328,7 @@ extension NSUserDefaults {
     }
     
     public subscript(key: DefaultsKey<[AnyObject]>) -> [AnyObject] {
-        get { return arrayForKey(key._key) ?? [] }
+        get { return arrayForKey(key._key) ?? key._default ?? [] }
         set { set(key, newValue) }
     }
 }
@@ -338,7 +340,7 @@ extension NSUserDefaults {
 
 extension NSUserDefaults {
     public func getArray<T: _ObjectiveCBridgeable>(key: DefaultsKey<[T]>) -> [T] {
-        return arrayForKey(key._key) as NSArray? as? [T] ?? []
+        return arrayForKey(key._key) as NSArray? as? [T] ?? key._default ?? []
     }
     
     public func getArray<T: _ObjectiveCBridgeable>(key: DefaultsKey<[T]?>) -> [T]? {
@@ -346,7 +348,7 @@ extension NSUserDefaults {
     }
     
     public func getArray<T: AnyObject>(key: DefaultsKey<[T]>) -> [T] {
-        return arrayForKey(key._key) as NSArray? as? [T] ?? []
+        return arrayForKey(key._key) as NSArray? as? [T] ?? key._default ?? []
     }
     
     public func getArray<T: AnyObject>(key: DefaultsKey<[T]?>) -> [T]? {

--- a/SwiftyUserDefaultsTests/SwiftyUserDefaultsTests.swift
+++ b/SwiftyUserDefaultsTests/SwiftyUserDefaultsTests.swift
@@ -187,6 +187,11 @@ class SwiftyUserDefaultsTests: XCTestCase {
         XCTAssert(Defaults[key] == "foobar")
     }
     
+    func testStaticDefaultString() {
+        let key = DefaultsKey<String>("none", "default")
+        XCTAssert(Defaults[key] == "default")
+    }
+    
     func testStaticIntOptional() {
         let key = DefaultsKey<Int?>("int")
         XCTAssert(Defaults[key] == nil)
@@ -199,6 +204,11 @@ class SwiftyUserDefaultsTests: XCTestCase {
         XCTAssert(Defaults[key] == 0)
         Defaults[key] += 10
         XCTAssert(Defaults[key] == 10)
+    }
+    
+    func testStaticDefaultInt() {
+        let key = DefaultsKey<Int>("none", 42)
+        XCTAssert(Defaults[key] == 42)
     }
     
     func testStaticDoubleOptional() {
@@ -214,6 +224,11 @@ class SwiftyUserDefaultsTests: XCTestCase {
         Defaults[key] = 2.14
         Defaults[key] += 1
         XCTAssert(Defaults[key] == 3.14)
+    }
+    
+    func testStaticDefaultDouble() {
+        let key = DefaultsKey<Double>("none", 42.0)
+        XCTAssert(Defaults[key] == 42.0)
     }
     
     func testStaticBoolOptional() {
@@ -233,6 +248,11 @@ class SwiftyUserDefaultsTests: XCTestCase {
         XCTAssert(Defaults[key] == true)
         Defaults[key] = false
         XCTAssert(Defaults[key] == false)
+    }
+    
+    func testStaticDefaultBool() {
+        let key = DefaultsKey<Bool>("none", true)
+        XCTAssert(Defaults[key] == true)
     }
     
     func testStaticAnyObject() {


### PR DESCRIPTION
It implements the idea discussed in #51 

``` swift
extension DefaultsKeys {
    static let username = DefaultsKey<String>("username", "default")
    static let launchCount = DefaultsKey<Int>("launchCount", 42)
}
```

Feedback is welcome :smiley:

cc @radex @kaunteya @thellimist
