### PR TITLE
Fix the warning of directory not found

### DIFF
--- a/SwiftyUserDefaults.xcodeproj/project.pbxproj
+++ b/SwiftyUserDefaults.xcodeproj/project.pbxproj
@@ -767,7 +767,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				FRAMEWORK_SEARCH_PATHS = (
-					"$(SDKROOT)/Developer/Library/Frameworks",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
 					"$(inherited)",
 				);
 				GCC_PREPROCESSOR_DEFINITIONS = (
@@ -785,7 +785,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				FRAMEWORK_SEARCH_PATHS = (
-					"$(SDKROOT)/Developer/Library/Frameworks",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
 					"$(inherited)",
 				);
 				INFOPLIST_FILE = SwiftyUserDefaultsTests/Info.plist;


### PR DESCRIPTION
This could fix the one of the warnings mentioned in #49.

> ld: warning: directory not found for option '-F/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.1.sdk/Developer/Library/Frameworks'

I guess the other warnings are not meant to be resolved?