### PR TITLE
Added optional default value to DefaultsKey

### DIFF
--- a/Sources/SwiftyUserDefaults.swift
+++ b/Sources/SwiftyUserDefaults.swift
@@ -189,14 +189,19 @@ public class DefaultsKeys {
 }
 
 /// Base class for static user defaults keys. Specialize with value type
-/// and pass key name to the initializer to create a key.
+/// and pass `key` name to the initializer to create a key.
+/// Optionally a `defaultValue` can be used as a fallback for this key.
 
 public class DefaultsKey<ValueType>: DefaultsKeys {
     // TODO: Can we use protocols to ensure ValueType is a compatible type?
     public let _key: String
     
-    public init(_ key: String) {
+    public init(_ key: String, _ defaultValue: ValueType? = nil) {
         self._key = key
+
+        if let object = defaultValue as? AnyObject {
+            Defaults.registerDefaults([key: object])
+        }
     }
 }
 


### PR DESCRIPTION
Currently SwiftyUserDefaults relies on pre-defined values for non-optional keys (e.g. `Bool` defaults to `false`, `Double` defaults to `0.0`).
If an app requires a different "stock" value, a developer has to manually use `Defaults.registerDefaults` method which is not statically typed.

This new `init` method for `DefaultsKey` automatically adds a default value "to the end of the search list" before the value is accessed (using the `DefaultsKey`) for the first time.

The change does not affect source compatibility.

Example:

```
extension DefaultsKeys {
    static let enabled = DefaultsKey<Bool>("Enabled", true)
}
```
