### PR TITLE
Add ability to return values composed of more than one user default

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: objective-c
 cache: cocoapods
 rvm: 2.2.2
-osx_image: xcode7.2
+osx_image: xcode7.3
 
 before_install:
 - gem install cocoapods
@@ -9,12 +9,12 @@ before_install:
 
 script:
 - set -o pipefail && xctool build -project SwiftyUserDefaults.xcodeproj -scheme 'SwiftyUserDefaults' -destination 'name=iPhone 6,OS=9.2' ONLY_ACTIVE_ARCH=NO CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO | xcpretty
-- set -o pipefail && xctool build -project SwiftyUserDefaults.xcodeproj -scheme 'SwiftyUserDefaults tvOS' -sdk appletvsimulator9.1 -destination 'name=Apple TV 1080p' ONLY_ACTIVE_ARCH=NO CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO | xcpretty
+- set -o pipefail && xctool build -project SwiftyUserDefaults.xcodeproj -scheme 'SwiftyUserDefaults tvOS' -sdk appletvsimulator9.2 -destination 'name=Apple TV 1080p' ONLY_ACTIVE_ARCH=NO CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO | xcpretty
 - set -o pipefail && xctool build -project SwiftyUserDefaults.xcodeproj -scheme 'SwiftyUserDefaults watchOS' -sdk iphonesimulator -destination 'name=Apple Watch - 42mm' ONLY_ACTIVE_ARCH=NO CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO | xcpretty
 - set -o pipefail && xctool build -project SwiftyUserDefaults.xcodeproj -scheme 'SwiftyUserDefaults Mac' ONLY_ACTIVE_ARCH=NO CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO | xcpretty
 
 - set -o pipefail && xctool test -project SwiftyUserDefaults.xcodeproj -scheme 'SwiftyUserDefaults' -sdk iphonesimulator -destination 'name=iPhone 6,OS=9.2' ONLY_ACTIVE_ARCH=NO CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO | xcpretty
-- set -o pipefail && xctool test -project SwiftyUserDefaults.xcodeproj -scheme 'SwiftyUserDefaults tvOS' -sdk appletvsimulator9.1 -destination 'name=Apple TV 1080p' ONLY_ACTIVE_ARCH=NO CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO | xcpretty
+- set -o pipefail && xctool test -project SwiftyUserDefaults.xcodeproj -scheme 'SwiftyUserDefaults tvOS' -sdk appletvsimulator9.2 -destination 'name=Apple TV 1080p' ONLY_ACTIVE_ARCH=NO CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO | xcpretty
 - set -o pipefail && xctool test -project SwiftyUserDefaults.xcodeproj -scheme 'SwiftyUserDefaults watchOS' -sdk iphonesimulator -destination 'name=Apple Watch - 42mm' ONLY_ACTIVE_ARCH=NO CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO | xcpretty
 - set -o pipefail && xctool test -project SwiftyUserDefaults.xcodeproj -scheme 'SwiftyUserDefaults Mac' ONLY_ACTIVE_ARCH=NO CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO | xcpretty
 

--- a/Sources/SwiftyUserDefaults.swift
+++ b/Sources/SwiftyUserDefaults.swift
@@ -200,6 +200,20 @@ public class DefaultsKey<ValueType>: DefaultsKeys {
     }
 }
 
+public protocol CompositeType {
+    // CompositeType is composed of values of type ValueType (e.g. CGRect is composed of CGFloats)
+    associatedtype ValueType
+}
+
+/// Base class for values that are a composite of two user defaults keys.
+public class CompositeDefaultsKey<ValueType: CompositeType> {
+    public let _keys: [DefaultsKey<ValueType.ValueType>]
+
+    public init(_ keys: [String]) {
+        _keys = keys.map { DefaultsKey($0) }
+    }
+}
+
 extension NSUserDefaults {
     /// This function allows you to create your own custom Defaults subscript. Example: [Int: String]
     public func set<T>(key: DefaultsKey<T>, _ value: Any?) {

--- a/Tests/SwiftyUserDefaultsTests.swift
+++ b/Tests/SwiftyUserDefaultsTests.swift
@@ -578,9 +578,47 @@ class SwiftyUserDefaultsTests: XCTestCase {
         Defaults[key] = nil
         XCTAssert(Defaults[key] == nil)
     }
+
+    func testComposite() {
+        let size1 = CGSize(width: 12.3, height: 3.21)
+        let size2 = CGSize(width: 32.1, height: 1.23)
+        let key = CompositeDefaultsKey<CGSize>(["width", "height"])
+        XCTAssert(Defaults[key] == .zero)
+        Defaults[key] = size1
+        XCTAssert(Defaults[key] == size1)
+        Defaults[key] = size2
+        XCTAssert(Defaults[key] == size2)
+        Defaults[key] = .zero
+        XCTAssert(Defaults[key] == .zero)
+    }
 }
 
 extension DefaultsKeys {
     static let strings = DefaultsKey<[String]>("strings")
     static let optStrings = DefaultsKey<[String]?>("strings")
 }
+
+extension CGSize : CompositeType {
+    public typealias ValueType = CGFloat
+}
+
+public extension NSUserDefaults {
+    public subscript(key: CompositeDefaultsKey<CGSize>) -> CGSize {
+        get {
+            let width  = self[key._keys[0]]
+            let height = self[key._keys[1]]
+            return CGSize(width: CGFloat(width), height: CGFloat(height))
+        }
+
+        set {
+            self[key._keys[0]] = newValue.width
+            self[key._keys[1]] = newValue.height
+        }
+    }
+
+    public subscript(key: DefaultsKey<CGFloat>) -> CGFloat {
+        get { return CGFloat(numberForKey(key._key)?.doubleValue ?? 0.0) }
+        set { self[key._key] = Double(newValue) }
+    }
+}
+


### PR DESCRIPTION
For example, a `CGSize` is composed of two `CGFloats`: width and height.  In some cases it makes sense to store these values in `NSUserDefaults` as separate values.

This commit adds a new class `CompositeDefaultsKey` that allows you to define values composed of more than one key.

Feedback welcome.
