### PR TITLE
Add KVO with Swift 3 support

### DIFF
--- a/Sources/DefaultsKVO.swift
+++ b/Sources/DefaultsKVO.swift
@@ -79,6 +79,10 @@ public struct DefaultsKVO {
         instance._handlers[key] = handlers(key: key).appending(handler)
     }
 
+    public static func hasHandlers(forKey key: String) -> Bool {
+        return !handlers(key: key).isEmpty
+    }
+
     public static func notifyHandlers(forKey key: String, newValue value: UserDefaults.Proxy) {
 
         handlers(key: key).forEach { $0.handler?(value) }

--- a/Sources/DefaultsKVO.swift
+++ b/Sources/DefaultsKVO.swift
@@ -1,0 +1,130 @@
+//
+// DefaultsKVO
+// Created by Christian Tietze on 2016-11-26.
+// Adapted from github.com/toshi0383
+//
+// Copyright (c) 2015-2016 Radosław Pietruszewski
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+
+import Foundation
+
+public struct DefaultsKVO {
+
+    public typealias Token = Int64
+    public typealias EventHandler = (UserDefaults.Proxy) -> Void
+
+    private static let lock: NSRecursiveLock = {
+        let lock = NSRecursiveLock()
+        lock.name = "radex.SwiftyUserDefaults"
+        return lock
+    }()
+    private static var instance = DefaultsKVO()
+
+    private var _nextToken: Token = 0
+
+    public static func nextToken() -> Token {
+
+        lock.lock()
+        let token = instance._nextToken
+        instance._nextToken += 1
+        lock.unlock()
+
+        return token
+    }
+}
+
+private var SwiftyUserDefaultsKVOContext: UnsafeMutableRawPointer? = nil
+private var kvoKeyAndHandlers = [String: [BlockDisposable]]()
+
+public final class BlockDisposable {
+
+    let key: String
+    private let token: DefaultsKVO.Token
+    var handler: DefaultsKVO.EventHandler?
+
+    init(key: String, handler: @escaping DefaultsKVO.EventHandler) {
+
+        self.token = DefaultsKVO.nextToken()
+
+        self.key = key
+        self.handler = handler
+    }
+
+    public func dispose() {
+
+        guard var handlers = kvoKeyAndHandlers[key]
+            else { return }
+
+        if let idx = handlers.index(where: { e in
+            return e.token == self.token
+        }) {
+            handlers.remove(at: idx)
+        }
+        Defaults.removeObserver(Defaults, forKeyPath: key)
+        handler = nil
+    }
+}
+
+extension UserDefaults {
+
+    public func observe(
+        key: String,
+        options: NSKeyValueObservingOptions = [.new],
+        handler: @escaping DefaultsKVO.EventHandler) -> BlockDisposable {
+
+        let key = DefaultsKey<String>(key)
+        return observe(key: key, handler: handler)
+    }
+
+    public func observe<T>(
+        key: DefaultsKey<T>,
+        options: NSKeyValueObservingOptions = [.new],
+        handler: @escaping DefaultsKVO.EventHandler) -> BlockDisposable {
+
+        let block = BlockDisposable(key: key._key, handler: handler)
+        if let _ = kvoKeyAndHandlers[key._key] {
+            kvoKeyAndHandlers[key._key]!.append(block)
+        } else {
+            kvoKeyAndHandlers[key._key] = [block]
+        }
+        self.addObserver(self, forKeyPath: key._key,
+                         options: options, context: SwiftyUserDefaultsKVOContext)
+        return block
+    }
+
+    open override func observeValue(
+        forKeyPath maybeKeyPath: String?,
+        of object: Any?,
+        change: [NSKeyValueChangeKey : Any]?,
+        context: UnsafeMutableRawPointer?) {
+
+        guard let keyPath = maybeKeyPath,
+            let handlers = kvoKeyAndHandlers[keyPath],
+            context == SwiftyUserDefaultsKVOContext
+            else {
+                super.observeValue(forKeyPath: maybeKeyPath, of: object, change: change, context: context);
+                return
+        }
+        
+        let value: Proxy = Defaults[keyPath]
+        handlers.forEach { $0.handler?(value) }
+    }
+}

--- a/SwiftyUserDefaults.xcodeproj/project.pbxproj
+++ b/SwiftyUserDefaults.xcodeproj/project.pbxproj
@@ -11,6 +11,9 @@
 		509865D21DE997A500D976CB /* DefaultsKVO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 509865D01DE997A500D976CB /* DefaultsKVO.swift */; };
 		509865D31DE997A500D976CB /* DefaultsKVO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 509865D01DE997A500D976CB /* DefaultsKVO.swift */; };
 		509865D41DE997A500D976CB /* DefaultsKVO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 509865D01DE997A500D976CB /* DefaultsKVO.swift */; };
+		509865D61DE9987D00D976CB /* DefaultsKVOTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 509865D51DE9987D00D976CB /* DefaultsKVOTests.swift */; };
+		509865D71DE99B6300D976CB /* DefaultsKVOTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 509865D51DE9987D00D976CB /* DefaultsKVOTests.swift */; };
+		509865D81DE99B6400D976CB /* DefaultsKVOTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 509865D51DE9987D00D976CB /* DefaultsKVOTests.swift */; };
 		52368ED71BE79AA60082969A /* SwiftyUserDefaults.h in Headers */ = {isa = PBXBuildFile; fileRef = 70264EA31B0DF85200B32B18 /* SwiftyUserDefaults.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		52368ED81BE79AAC0082969A /* SwiftyUserDefaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70264EBA1B0DF8B900B32B18 /* SwiftyUserDefaults.swift */; };
 		52368EE21BE79B350082969A /* SwiftyUserDefaults.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 52368ECF1BE79A9B0082969A /* SwiftyUserDefaults.framework */; };
@@ -57,6 +60,7 @@
 
 /* Begin PBXFileReference section */
 		509865D01DE997A500D976CB /* DefaultsKVO.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DefaultsKVO.swift; sourceTree = "<group>"; };
+		509865D51DE9987D00D976CB /* DefaultsKVOTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DefaultsKVOTests.swift; sourceTree = "<group>"; };
 		52368ECF1BE79A9B0082969A /* SwiftyUserDefaults.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SwiftyUserDefaults.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		52368EDD1BE79B350082969A /* SwiftyUserDefaults tvOSTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "SwiftyUserDefaults tvOSTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		52E169451BE8089000116EA1 /* SwiftyUserDefaults.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SwiftyUserDefaults.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -170,6 +174,7 @@
 			isa = PBXGroup;
 			children = (
 				70264EB01B0DF85300B32B18 /* SwiftyUserDefaultsTests.swift */,
+				509865D51DE9987D00D976CB /* DefaultsKVOTests.swift */,
 				6E903A8B1B66338C004CDFC4 /* TestHelper.swift */,
 				70264EAE1B0DF85300B32B18 /* Supporting Files */,
 			);
@@ -471,6 +476,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				509865D81DE99B6400D976CB /* DefaultsKVOTests.swift in Sources */,
 				52368EE81BE79B530082969A /* SwiftyUserDefaultsTests.swift in Sources */,
 				52368EE91BE79B560082969A /* TestHelper.swift in Sources */,
 			);
@@ -498,6 +504,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				509865D61DE9987D00D976CB /* DefaultsKVOTests.swift in Sources */,
 				70264EB11B0DF85300B32B18 /* SwiftyUserDefaultsTests.swift in Sources */,
 				6E903A8C1B66338C004CDFC4 /* TestHelper.swift in Sources */,
 			);
@@ -516,6 +523,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				509865D71DE99B6300D976CB /* DefaultsKVOTests.swift in Sources */,
 				D9D2CFC31B54AB3B00D6ABCE /* SwiftyUserDefaultsTests.swift in Sources */,
 				6E903A8D1B66338C004CDFC4 /* TestHelper.swift in Sources */,
 			);

--- a/SwiftyUserDefaults.xcodeproj/project.pbxproj
+++ b/SwiftyUserDefaults.xcodeproj/project.pbxproj
@@ -7,6 +7,10 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		509865D11DE997A500D976CB /* DefaultsKVO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 509865D01DE997A500D976CB /* DefaultsKVO.swift */; };
+		509865D21DE997A500D976CB /* DefaultsKVO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 509865D01DE997A500D976CB /* DefaultsKVO.swift */; };
+		509865D31DE997A500D976CB /* DefaultsKVO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 509865D01DE997A500D976CB /* DefaultsKVO.swift */; };
+		509865D41DE997A500D976CB /* DefaultsKVO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 509865D01DE997A500D976CB /* DefaultsKVO.swift */; };
 		52368ED71BE79AA60082969A /* SwiftyUserDefaults.h in Headers */ = {isa = PBXBuildFile; fileRef = 70264EA31B0DF85200B32B18 /* SwiftyUserDefaults.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		52368ED81BE79AAC0082969A /* SwiftyUserDefaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70264EBA1B0DF8B900B32B18 /* SwiftyUserDefaults.swift */; };
 		52368EE21BE79B350082969A /* SwiftyUserDefaults.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 52368ECF1BE79A9B0082969A /* SwiftyUserDefaults.framework */; };
@@ -52,6 +56,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		509865D01DE997A500D976CB /* DefaultsKVO.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DefaultsKVO.swift; sourceTree = "<group>"; };
 		52368ECF1BE79A9B0082969A /* SwiftyUserDefaults.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SwiftyUserDefaults.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		52368EDD1BE79B350082969A /* SwiftyUserDefaults tvOSTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "SwiftyUserDefaults tvOSTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		52E169451BE8089000116EA1 /* SwiftyUserDefaults.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SwiftyUserDefaults.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -154,6 +159,7 @@
 			children = (
 				70264EA31B0DF85200B32B18 /* SwiftyUserDefaults.h */,
 				70264EBA1B0DF8B900B32B18 /* SwiftyUserDefaults.swift */,
+				509865D01DE997A500D976CB /* DefaultsKVO.swift */,
 				70264EA21B0DF85200B32B18 /* Info.plist */,
 			);
 			name = SwiftyUserDefaults;
@@ -456,6 +462,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				509865D31DE997A500D976CB /* DefaultsKVO.swift in Sources */,
 				52368ED81BE79AAC0082969A /* SwiftyUserDefaults.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -473,6 +480,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				509865D41DE997A500D976CB /* DefaultsKVO.swift in Sources */,
 				52E1694E1BE808B900116EA1 /* SwiftyUserDefaults.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -481,6 +489,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				509865D11DE997A500D976CB /* DefaultsKVO.swift in Sources */,
 				70264EBB1B0DF8B900B32B18 /* SwiftyUserDefaults.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -498,6 +507,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				509865D21DE997A500D976CB /* DefaultsKVO.swift in Sources */,
 				D9D2CFC21B54AB3500D6ABCE /* SwiftyUserDefaults.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Tests/DefaultsKVOTests.swift
+++ b/Tests/DefaultsKVOTests.swift
@@ -29,11 +29,11 @@ class DefaultsKVOTests: XCTestCase {
         let disposable = Defaults.observe(key: "count") { proxy in
             XCTFail()
         }
-        XCTAssert(DefaultsKVO.hasHandlers(forKey: "count"))
+        XCTAssert(UserDefaults.KVO.hasHandlers(forKey: "count"))
         disposable.dispose()
         Defaults["count"] = 1
         XCTAssert(disposable.handler == nil)
-        XCTAssertFalse(DefaultsKVO.hasHandlers(forKey: "count"))
+        XCTAssertFalse(UserDefaults.KVO.hasHandlers(forKey: "count"))
     }
 
     func testKVO_DisposingRemovesHandler() {

--- a/Tests/DefaultsKVOTests.swift
+++ b/Tests/DefaultsKVOTests.swift
@@ -1,0 +1,75 @@
+import XCTest
+@testable import SwiftyUserDefaults
+
+class DefaultsKVOTests: XCTestCase {
+
+    override func setUp() {
+        super.setUp()
+        clearDefaults()
+    }
+
+    func testKVO_ReceivesChanges() {
+        Defaults["count"] = 0
+        let ex = expectation(description: "`count` should be increased.")
+        let disposable = Defaults.observe(key: "count") { proxy in
+            if let int = proxy.int, int == 1 {
+                ex.fulfill()
+            } else {
+                XCTFail()
+            }
+        }
+        Defaults["count"] = 1
+        waitForExpectations(timeout: 0.1, handler: nil)
+        disposable.dispose()
+        Defaults.remove("count")
+    }
+
+    func testKVO_DisposingRemovesObserver() {
+        Defaults["count"] = 0
+        let disposable = Defaults.observe(key: "count") { proxy in
+            XCTFail()
+        }
+        disposable.dispose()
+        Defaults["count"] = 1
+        XCTAssert(disposable.handler == nil)
+    }
+
+    func testKVO_DisposingRemovesHandler() {
+        Defaults["count"] = 0
+        let disposable = Defaults.observe(key: "count") { proxy in
+            XCTFail()
+        }
+        let ex = expectation(description: "`count` should be increased.")
+        let disposable2 = Defaults.observe(key: "count") { proxy in
+            if let int = proxy.int, int == 1 {
+                ex.fulfill()
+            } else {
+                XCTFail()
+            }
+        }
+        disposable.dispose()
+        Defaults["count"] = 1
+        XCTAssert(disposable.handler == nil)
+        XCTAssert(disposable2.handler != nil)
+        waitForExpectations(timeout: 0.1, handler: nil)
+        disposable2.dispose()
+
+        XCTAssert(disposable2.handler == nil)
+    }
+
+    func testKVO_WithPlainFoundation() {
+        UserDefaults.standard.set(0, forKey: "count")
+        let ex = expectation(description: "`count` should be increased.")
+        let disposable = Defaults.observe(key: "count") { proxy in
+
+            if let int = proxy.int, int == 1 {
+                ex.fulfill()
+            } else {
+                XCTFail()
+            }
+        }
+        UserDefaults.standard.set(1, forKey: "count")
+        waitForExpectations(timeout: 0.1, handler: nil)
+        disposable.dispose()
+    }
+}

--- a/Tests/DefaultsKVOTests.swift
+++ b/Tests/DefaultsKVOTests.swift
@@ -29,9 +29,11 @@ class DefaultsKVOTests: XCTestCase {
         let disposable = Defaults.observe(key: "count") { proxy in
             XCTFail()
         }
+        XCTAssert(DefaultsKVO.hasHandlers(forKey: "count"))
         disposable.dispose()
         Defaults["count"] = 1
         XCTAssert(disposable.handler == nil)
+        XCTAssertFalse(DefaultsKVO.hasHandlers(forKey: "count"))
     }
 
     func testKVO_DisposingRemovesHandler() {

--- a/Tests/SwiftyUserDefaultsTests.swift
+++ b/Tests/SwiftyUserDefaultsTests.swift
@@ -3,10 +3,7 @@ import XCTest
 
 class SwiftyUserDefaultsTests: XCTestCase {
     override func setUp() {
-        // clear defaults before testing
-        for (key, _) in Defaults.dictionaryRepresentation() {
-            Defaults.removeObject(forKey: key)
-        }
+        clearDefaults()
         super.tearDown()
     }
 

--- a/Tests/TestHelper.swift
+++ b/Tests/TestHelper.swift
@@ -54,3 +54,9 @@ extension UserDefaults {
         set { archive(key, newValue) }
     }
 }
+
+func clearDefaults() {
+    for (key, _) in Defaults.dictionaryRepresentation() {
+        Defaults.removeObject(forKey: key)
+    }
+}


### PR DESCRIPTION
May solve #87 and replace #67.

Basically an up-to-date version of @toshi0383 with less global values.

Should this be an additional module so users can decide to not plug it in? (RxSwift, for example, provides its own observation abstraction.)