### PR TITLE
added test case for comparing nil value against non-nil value

### DIFF
--- a/Tests/SwiftyUserDefaultsTests/TestHelpers/DefaultsSerializableSpec.swift
+++ b/Tests/SwiftyUserDefaultsTests/TestHelpers/DefaultsSerializableSpec.swift
@@ -240,6 +240,12 @@ extension DefaultsSerializableSpec where Serializable.T: Equatable, Serializable
                 defaults[key] = nil
                 expect(defaults[key]).to(beNil())
             }
+            
+            then("compare a value") {
+                let key = DefaultsKey<Serializable?>("test")
+                expect(defaults[key] == nil).to(beTrue())
+                expect(defaults[key] != self.defaultValue).to(beTrue())
+            }
         }
     }
 }


### PR DESCRIPTION
This is causing the subscript to go through the non-optional DefaultsKey path which then throws a fatal error.