### PR TITLE
Support plist & launch arguments for Bool/String/Double/Int.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ### Next
 
 * Brought back dictionary support for `[String: Any]`/`[String: String]` and corresponding array version of it `[[String: Any]]`/`[[String: String]]`. [@sunshinejr](https://github.com/sunshinejr)
+* Added support for launch arguments/plist booleans. [@sunshinejr](https://github.com/sunshinejr)
 
 ### 4.0.0-alpha.3 (2019-02-19)
 

--- a/README.md
+++ b/README.md
@@ -2,8 +2,9 @@
 
 ![Platforms](https://img.shields.io/badge/platforms-ios%20%7C%20osx%20%7C%20watchos%20%7C%20tvos-lightgrey.svg)
 [![CI Status](https://api.travis-ci.org/radex/SwiftyUserDefaults.svg?branch=master)](https://travis-ci.org/radex/SwiftyUserDefaults)
-[![CocoaPods](http://img.shields.io/cocoapods/v/SwiftyUserDefaults.svg)](https://cocoapods.org/pods/SwiftyUserDefaults)
+[![CocoaPods](http://img.shields.io/cocoapods/v/SwiftyUserDefaults.svg)](#cocoapods)
 [![Carthage compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](#carthage)
+[![SPM compatible](https://img.shields.io/badge/SPM-compatible-4BC51D.svg?style=flat)](#swift-package-manager)
 ![Swift version](https://img.shields.io/badge/swift-4.1-orange.svg)
 ![Swift version](https://img.shields.io/badge/swift-4.2-orange.svg)
 ![Swift version](https://img.shields.io/badge/swift-5.0-orange.svg)

--- a/README.md
+++ b/README.md
@@ -9,14 +9,13 @@
 ![Swift version](https://img.shields.io/badge/swift-5.0-orange.svg)
 
 #### Modern Swift API for `NSUserDefaults`
-###### SwiftyUserDefaults makes user defaults enjoyable to use by combining expressive Swifty API with the benefits of static typing. Define your keys in one place, use value types easily, and get extra safety and convenient compile-time checks for free.
+###### SwiftyUserDefaults makes user defaults enjoyable to use by combining expressive Swifty API with the benefits of static typing. Define your keys in one place, use value types easily, and get extra safety and convenient compile-time checks for free. Oh, and add any type that you want to store with ease :-)
 
-Read [Statically-typed NSUserDefaults](http://radex.io/swift/nsuserdefaults/static) for more information about this project.<br />
 Read [documentation for stable version 3.0.1](https://github.com/radex/SwiftyUserDefaults/blob/14b629b035bf6355b46ece22c3851068a488a895/README.md)<br />
 Read [migration guide from version 3.x to 4.x](MigrationGuides/migration_3_to_4.md)<br />
 Read [migration guide from version 4.0.0-alpha.1 to 4.0.0-alpha.3](MigrationGuides/migration_4_alpha_1_to_4_alpha_2.md)
 
-# Version 4 - alpha 2
+# Version 4 - alpha 3
 
 <p align="center">
     <a href="#features">Features</a> &bull;
@@ -26,6 +25,7 @@ Read [migration guide from version 4.0.0-alpha.1 to 4.0.0-alpha.3](MigrationGuid
     <a href="#rawrepresentable">RawRepresentable</a> &bull;
     <a href="#extending-existing-types">Extending existing types</a> &bull;
     <a href="#custom-types">Custom types</a> &bull;
+    <a href="#launch-arguments">Launch arguments</a> &bull;
     <a href="#installation">Installation</a>
 </p>
 
@@ -279,6 +279,28 @@ extension Data: DefaultsSerializable {
 
 Also, take a look at our source code (or tests) to see more examples of bridges. If you find yourself confused with all these bridges, please [create an issue](https://github.com/radex/SwiftyUserDefaults/issues/new) and we will figure something out.
 
+### Launch arguments
+
+Do you like to customize your app/script/tests by UserDefaults? Now it's fully supported on our side, statically typed of course. 
+
+_Note: for now we support only `Bool`, `Double`, `Int`, `String` values, but if you have any other requests for that feature, please open an issue or PR and we can talk about implementing it in new versions._
+
+#### You can pass your arguments in your schema:
+<img src="https://i.imgur.com/SDpOBpK.png" alt="Pass launch arguments in Xcode Schema editor." />
+
+#### Or you can use launch arguments in XCUIApplication:
+```swift
+func testExample() {
+    let app = XCUIApplication()
+    app.launchArguments = ["-skipLogin", "true", "-loginTries", "3", "-lastGameTime", "61.3", "-nickname", "sunshinejr"]
+    app.launch()
+}
+```
+#### Or pass them as command line arguments!
+```bash
+./script -skipLogin true -loginTries 3 -lastGameTime 61.3 -nickname sunshinejr
+```
+
 ### Remove all keys
 
 To reset user defaults, use `removeAll` method.
@@ -298,11 +320,11 @@ var Defaults = UserDefaults(suiteName: "com.my.app")!
 ## Installation & Requirements
 
 #### Requirements
-**Swift** version >= **4.1**
-**iOS** version >= **8.0**
-**macOS** version >= **10.11**
-**tvOS** version >= **9.0**
-**watchOS** version >= **2.0**
+**Swift** version **>= 4.1**<br />
+**iOS** version **>= 8.0**<br />
+**macOS** version **>= 10.11**<br />
+**tvOS** version **>= 9.0**<br />
+**watchOS** version **>= 2.0**
 
 #### CocoaPods
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 [![CocoaPods](http://img.shields.io/cocoapods/v/SwiftyUserDefaults.svg)](https://cocoapods.org/pods/SwiftyUserDefaults)
 [![Carthage compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](#carthage)
 ![Swift version](https://img.shields.io/badge/swift-4.1-orange.svg)
+![Swift version](https://img.shields.io/badge/swift-4.2-orange.svg)
+![Swift version](https://img.shields.io/badge/swift-5.0-orange.svg)
 
 #### Modern Swift API for `NSUserDefaults`
 ###### SwiftyUserDefaults makes user defaults enjoyable to use by combining expressive Swifty API with the benefits of static typing. Define your keys in one place, use value types easily, and get extra safety and convenient compile-time checks for free.

--- a/README.md
+++ b/README.md
@@ -296,7 +296,11 @@ var Defaults = UserDefaults(suiteName: "com.my.app")!
 ## Installation & Requirements
 
 #### Requirements
-Swift version >= 4.1
+**Swift** version >= **4.1**
+**iOS** version >= **8.0**
+**macOS** version >= **10.11**
+**tvOS** version >= **9.0**
+**watchOS** version >= **2.0**
 
 #### CocoaPods
 

--- a/Sources/Defaults+StringToBool.swift
+++ b/Sources/Defaults+StringToBool.swift
@@ -1,0 +1,40 @@
+//
+// SwiftyUserDefaults
+//
+// Copyright (c) 2015-present Radosław Pietruszewski, Łukasz Mróz
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+
+import Foundation
+
+// We don't want to use `NSString.boolValue` as it's converting every miss to `false`, instead of `nil`
+internal extension String {
+    var bool: Bool? {
+        switch self.lowercased() {
+        case "true", "t", "yes", "y", "1":
+            return true
+        case "false", "f", "no", "n", "0":
+            return false
+        default:
+            return nil
+        }
+    }
+}
+

--- a/Sources/DefaultsBridges.swift
+++ b/Sources/DefaultsBridges.swift
@@ -95,9 +95,15 @@ public final class DefaultsBoolBridge: DefaultsBridge<Bool> {
     public override func get(key: String, userDefaults: UserDefaults) -> Bool? {
         // @warning we use number(forKey:) instead of bool(forKey:), because
         // bool(forKey:) will always return value, even if it's not set
-        // and it does a little bit of magic under the hood as well
-        // e.g. transforming strings like "YES" or "true" to true
-        return userDefaults.number(forKey: key)?.boolValue
+        //
+        // Now, let's see if there is value in defaults that converts to Bool first:
+        if let bool = userDefaults.number(forKey: key)?.boolValue {
+            return bool
+        }
+
+        // If not, fallback for values saved in a plist (e.g. for testing)
+        // For instance, few of the string("YES", "true", "NO", "false") convert to Bool from a property list
+        return (userDefaults.object(forKey: key) as? String)?.bool
     }
 }
 

--- a/Sources/DefaultsBridges.swift
+++ b/Sources/DefaultsBridges.swift
@@ -93,7 +93,17 @@ public final class DefaultsDoubleBridge: DefaultsBridge<Double> {
     }
 
     public override func get(key: String, userDefaults: UserDefaults) -> Double? {
-        return userDefaults.number(forKey: key)?.doubleValue
+        if let double = userDefaults.number(forKey: key)?.doubleValue {
+            return double
+        }
+
+        // Fallback for launch arguments
+        if let string = userDefaults.object(forKey: key) as? String,
+            let double = Double(string) {
+            return double
+        }
+
+        return nil
     }
 }
 

--- a/Sources/DefaultsBridges.swift
+++ b/Sources/DefaultsBridges.swift
@@ -73,7 +73,17 @@ public final class DefaultsIntBridge: DefaultsBridge<Int> {
     }
 
     public override func get(key: String, userDefaults: UserDefaults) -> Int? {
-        return userDefaults.number(forKey: key)?.intValue
+        if let int = userDefaults.number(forKey: key)?.intValue {
+            return int
+        }
+
+        // Fallback for launch arguments
+        if let string = userDefaults.object(forKey: key) as? String,
+            let int = Int(string) {
+            return int
+        }
+
+        return nil
     }
 }
 

--- a/SwiftyUserDefaults.xcodeproj/project.pbxproj
+++ b/SwiftyUserDefaults.xcodeproj/project.pbxproj
@@ -26,6 +26,7 @@
 		8551BC3D221207F20004E121 /* Defaults+FrogCustomSerializable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8551BC3C221207F20004E121 /* Defaults+FrogCustomSerializable.swift */; };
 		85ABD921221EDD32002E63D8 /* Defaults+Dictionary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85ABD920221EDD32002E63D8 /* Defaults+Dictionary.swift */; };
 		85E9D0AC22203B1100E0F0EA /* Defaults+StringToBool.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85E9D0AB22203B1100E0F0EA /* Defaults+StringToBool.swift */; };
+		85E9D0AE22203C6A00E0F0EA /* UserDefaults+PropertyList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85E9D0AD22203C6A00E0F0EA /* UserDefaults+PropertyList.swift */; };
 		OBJ_152 /* AdapterProtocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_76 /* AdapterProtocols.swift */; };
 		OBJ_153 /* AssertionDispatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_77 /* AssertionDispatcher.swift */; };
 		OBJ_154 /* AssertionRecorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_78 /* AssertionRecorder.swift */; };
@@ -181,6 +182,7 @@
 		8551BC3C221207F20004E121 /* Defaults+FrogCustomSerializable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Defaults+FrogCustomSerializable.swift"; sourceTree = "<group>"; };
 		85ABD920221EDD32002E63D8 /* Defaults+Dictionary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Defaults+Dictionary.swift"; sourceTree = "<group>"; };
 		85E9D0AB22203B1100E0F0EA /* Defaults+StringToBool.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Defaults+StringToBool.swift"; sourceTree = "<group>"; };
+		85E9D0AD22203C6A00E0F0EA /* UserDefaults+PropertyList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UserDefaults+PropertyList.swift"; sourceTree = "<group>"; };
 		"Nimble::Nimble::Product" /* Nimble.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Nimble.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		OBJ_10 /* Defaults+Subscripts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Defaults+Subscripts.swift"; sourceTree = "<group>"; };
 		OBJ_100 /* BeIdenticalTo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BeIdenticalTo.swift; sourceTree = "<group>"; };
@@ -439,6 +441,7 @@
 			children = (
 				OBJ_37 /* DefaultsSerializableSpec.swift */,
 				OBJ_38 /* TestHelper.swift */,
+				85E9D0AD22203C6A00E0F0EA /* UserDefaults+PropertyList.swift */,
 			);
 			path = TestHelpers;
 			sourceTree = "<group>";
@@ -989,6 +992,7 @@
 				OBJ_295 /* Defaults+URL.swift in Sources */,
 				OBJ_297 /* Defaults+BestFroggiesEnum.swift in Sources */,
 				8551BC3D221207F20004E121 /* Defaults+FrogCustomSerializable.swift in Sources */,
+				85E9D0AE22203C6A00E0F0EA /* UserDefaults+PropertyList.swift in Sources */,
 				OBJ_298 /* DefaultsSerializableSpec.swift in Sources */,
 				OBJ_299 /* TestHelper.swift in Sources */,
 			);

--- a/SwiftyUserDefaults.xcodeproj/project.pbxproj
+++ b/SwiftyUserDefaults.xcodeproj/project.pbxproj
@@ -25,6 +25,7 @@
 		8551BC3A2211F7D20004E121 /* DefaultsBridges.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8551BC392211F7D20004E121 /* DefaultsBridges.swift */; };
 		8551BC3D221207F20004E121 /* Defaults+FrogCustomSerializable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8551BC3C221207F20004E121 /* Defaults+FrogCustomSerializable.swift */; };
 		85ABD921221EDD32002E63D8 /* Defaults+Dictionary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85ABD920221EDD32002E63D8 /* Defaults+Dictionary.swift */; };
+		85E9D0AC22203B1100E0F0EA /* Defaults+StringToBool.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85E9D0AB22203B1100E0F0EA /* Defaults+StringToBool.swift */; };
 		OBJ_152 /* AdapterProtocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_76 /* AdapterProtocols.swift */; };
 		OBJ_153 /* AssertionDispatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_77 /* AssertionDispatcher.swift */; };
 		OBJ_154 /* AssertionRecorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_78 /* AssertionRecorder.swift */; };
@@ -179,6 +180,7 @@
 		8551BC392211F7D20004E121 /* DefaultsBridges.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultsBridges.swift; sourceTree = "<group>"; };
 		8551BC3C221207F20004E121 /* Defaults+FrogCustomSerializable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Defaults+FrogCustomSerializable.swift"; sourceTree = "<group>"; };
 		85ABD920221EDD32002E63D8 /* Defaults+Dictionary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Defaults+Dictionary.swift"; sourceTree = "<group>"; };
+		85E9D0AB22203B1100E0F0EA /* Defaults+StringToBool.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Defaults+StringToBool.swift"; sourceTree = "<group>"; };
 		"Nimble::Nimble::Product" /* Nimble.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Nimble.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		OBJ_10 /* Defaults+Subscripts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Defaults+Subscripts.swift"; sourceTree = "<group>"; };
 		OBJ_100 /* BeIdenticalTo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BeIdenticalTo.swift; sourceTree = "<group>"; };
@@ -557,6 +559,7 @@
 				OBJ_14 /* DefaultsSerializable.swift */,
 				OBJ_15 /* OptionalType.swift */,
 				8551BC392211F7D20004E121 /* DefaultsBridges.swift */,
+				85E9D0AB22203B1100E0F0EA /* Defaults+StringToBool.swift */,
 			);
 			path = Sources;
 			sourceTree = SOURCE_ROOT;
@@ -957,6 +960,7 @@
 				OBJ_264 /* DefaultsSerializable+BuiltIns.swift in Sources */,
 				OBJ_265 /* DefaultsSerializable.swift in Sources */,
 				OBJ_266 /* OptionalType.swift in Sources */,
+				85E9D0AC22203B1100E0F0EA /* Defaults+StringToBool.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Tests/SwiftyUserDefaultsTests/Primitives/Defaults+Bool.swift
+++ b/Tests/SwiftyUserDefaultsTests/Primitives/Defaults+Bool.swift
@@ -28,14 +28,34 @@ final class DefaultsBoolSpec: QuickSpec, DefaultsSerializableSpec {
 
     typealias Serializable = Bool
 
-    var customValue: Bool = false
-    var defaultValue: Bool = true
+    var customValue: Bool = true
+    var defaultValue: Bool = false
 
     override func spec() {
         given("Bool") {
             self.testValues()
             self.testOptionalValues()
             self.testOptionalValuesWithoutDefaultValue()
+            self.testPlistRegisteringValues(valueStrings: ["YES": true,
+                                                           "yes": true,
+                                                           "TRUE": true,
+                                                           "true": true,
+                                                           "Y": true,
+                                                           "y": true,
+                                                           "T": true,
+                                                           "t": true,
+                                                           "1": true,
+                                                           "NO": false,
+                                                           "no": false,
+                                                           "FALSE": false,
+                                                           "false": false,
+                                                           "N": false,
+                                                           "n": false,
+                                                           "f": false,
+                                                           "F": false,
+                                                           "0": false,
+                                                           "blabla": nil,
+                                                           "test": nil])
         }
     }
 }

--- a/Tests/SwiftyUserDefaultsTests/Primitives/Defaults+Double.swift
+++ b/Tests/SwiftyUserDefaultsTests/Primitives/Defaults+Double.swift
@@ -36,6 +36,10 @@ final class DefaultsDoubleSpec: QuickSpec, DefaultsSerializableSpec {
             self.testValues()
             self.testOptionalValues()
             self.testOptionalValuesWithoutDefaultValue()
+            self.testPlistRegisteringValues(valueStrings: ["0": 0.0,
+                                                           "1": 1.0,
+                                                           "2": 2.0,
+                                                           "31.0": 31.0])
         }
     }
 }

--- a/Tests/SwiftyUserDefaultsTests/Primitives/Defaults+Int.swift
+++ b/Tests/SwiftyUserDefaultsTests/Primitives/Defaults+Int.swift
@@ -35,6 +35,10 @@ final class DefaultsIntSpec: QuickSpec, DefaultsSerializableSpec {
             self.testValues()
             self.testOptionalValues()
             self.testOptionalValuesWithoutDefaultValue()
+            self.testPlistRegisteringValues(valueStrings: ["0": 0,
+                                                           "1": 1,
+                                                           "2": 2,
+                                                           "111111": 111111])
         }
     }
 }

--- a/Tests/SwiftyUserDefaultsTests/Primitives/Defaults+String.swift
+++ b/Tests/SwiftyUserDefaultsTests/Primitives/Defaults+String.swift
@@ -36,6 +36,8 @@ final class DefaultsStringSpec: QuickSpec, DefaultsSerializableSpec {
             self.testValues()
             self.testOptionalValues()
             self.testOptionalValuesWithoutDefaultValue()
+            self.testPlistRegisteringValues(valueStrings: ["0.0": "0.0",
+                                                           "test": "test"])
         }
     }
 }

--- a/Tests/SwiftyUserDefaultsTests/TestHelpers/UserDefaults+PropertyList.swift
+++ b/Tests/SwiftyUserDefaultsTests/TestHelpers/UserDefaults+PropertyList.swift
@@ -1,0 +1,75 @@
+//
+// SwiftyUserDefaults
+//
+// Copyright (c) 2015-present Radosław Pietruszewski, Łukasz Mróz
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+
+import Foundation
+
+fileprivate let propertyListPrefixes: Set<Character> = [ "{", "[", "(", "<", "\"" ]
+
+// Kudos to stdlib-corelibs-foundation:
+// https://github.com/apple/swift-corelibs-foundation/blob/master/Foundation/UserDefaults.swift#L415-L458
+internal extension UserDefaults {
+    static func _parseArguments(_ arguments: [String]) -> [String: Any] {
+        var result: [String: Any] = [:]
+
+        let count = arguments.count
+
+        var index = 0
+        while index < count - 1 { // We're looking for pairs, so stop at the second-to-last argument.
+            let current = arguments[index]
+            let next = arguments[index + 1]
+            if current.hasPrefix("-") && !next.hasPrefix("-") {
+                // Match what Darwin does, which is to check whether the first argument is one of the characters that make up a NeXTStep-style or XML property list: open brace, open parens, open bracket, open angle bracket, or double quote. If it is, attempt parsing it as a plist; otherwise, just use the argument value as a String.
+
+                let keySubstring = current[current.index(after: current.startIndex)...]
+                if !keySubstring.isEmpty {
+                    let key = String(keySubstring)
+                    let value = next.trimmingCharacters(in: .whitespacesAndNewlines)
+
+                    var parsed = false
+                    if let prefix = value.first, propertyListPrefixes.contains(prefix) {
+                        if let data = value.data(using: .utf8),
+                            let plist = try? PropertyListSerialization.propertyList(from: data, format: nil) {
+
+                            // If we can parse that argument as a plist, use the parsed value.
+                            parsed = true
+                            result[key] = plist
+
+                        }
+                    }
+
+                    if !parsed {
+                        result[key] = value
+                    }
+                }
+
+                index += 1 // Skip both the key and the value on this loop.
+            }
+
+            index += 1
+        }
+
+        return result
+    }
+}
+


### PR DESCRIPTION
Fixes #159, fixes #148, supersedes #149.

This resolves the problem with supporting launch bool arguments and still returning nil for false-positives (that `bool(for:)` returns, e.g. for string `test` it still returns `true` or for string `blabla` it returns `false`).

**Update:** Managed to add String, Int and Double as well!

TODO:
- [ ] Add Readme doc with an example usage.