### PR TITLE
[WIP] use DefaultsKey.defaultValue for registering user defaults

### DIFF
--- a/Defaults+RegisterDefaults.swift
+++ b/Defaults+RegisterDefaults.swift
@@ -1,0 +1,56 @@
+//
+// SwiftyUserDefaults
+//
+// Copyright (c) 2015-present Radosław Pietruszewski, Łukasz Mróz
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+
+import Foundation
+
+public protocol DefaultsKeyable {
+    var _key: String { get }
+    var _defaultValue: Any? { get }
+}
+
+extension DefaultsKey: DefaultsKeyable {
+    public var _defaultValue: Any? {
+        return self.defaultValue as Any?
+    }
+}
+
+public extension UserDefaults {
+    func register(defaultsKeys: [DefaultsKeyable]) {
+        let defaults: [String : Any] = defaultsKeys
+            .filter { $0._defaultValue != nil }
+            .mapDictionary { ($0._key, $0._defaultValue!) }
+        self.register(defaults: defaults)
+    }
+}
+
+internal extension Array {
+    func mapDictionary<K, V>(_ transform: (Element) -> ((K, V))) -> [K : V] {
+        var result: [K : V] = [:]
+        for element in self {
+            let (key, value) = transform(element)
+            result[key] = value
+        }
+        return result
+    }
+}

--- a/SwiftyUserDefaults.xcodeproj/project.pbxproj
+++ b/SwiftyUserDefaults.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		311F24C3509BE924078AD67E /* DefaultsObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9701991125BC1345631E831E /* DefaultsObserver.swift */; };
 		499B0191487C22E03028ED3C /* Defaults+Int.swift in Sources */ = {isa = PBXBuildFile; fileRef = 041FE3F6B58F219CAAE0AD64 /* Defaults+Int.swift */; };
 		4B604921053C4F31217DCE9E /* Defaults+Observing.swift in Sources */ = {isa = PBXBuildFile; fileRef = F910BE3FABE99289E0545D95 /* Defaults+Observing.swift */; };
+		50B63B342265BBE300CCB151 /* Defaults+RegisterDefaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50B63B332265BBE300CCB151 /* Defaults+RegisterDefaults.swift */; };
 		7EE5BB8911DFD47B6D6ED8E5 /* Defaults+Date.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F97C9DDE34857798EA6519B /* Defaults+Date.swift */; };
 		80C1C495919531D69B34BA6F /* Defaults+Data.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78703A0F180A4B7C450CD191 /* Defaults+Data.swift */; };
 		88573499C0B9C4F466D7EC2D /* DefaultsSerializable.swift in Sources */ = {isa = PBXBuildFile; fileRef = F98C7EF97445788836162CD0 /* DefaultsSerializable.swift */; };
@@ -55,6 +56,7 @@
 		2EFFE22277FA6C163E34F4D2 /* DefaultsSerializableSpec.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DefaultsSerializableSpec.swift; path = Tests/SwiftyUserDefaultsTests/TestHelpers/DefaultsSerializableSpec.swift; sourceTree = "<group>"; };
 		2F97C9DDE34857798EA6519B /* Defaults+Date.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Defaults+Date.swift"; path = "Tests/SwiftyUserDefaultsTests/Built-ins/Defaults+Date.swift"; sourceTree = "<group>"; };
 		3D8980553F1615D4ACB4AA43 /* Defaults+Dictionary.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Defaults+Dictionary.swift"; path = "Tests/SwiftyUserDefaultsTests/Built-ins/Defaults+Dictionary.swift"; sourceTree = "<group>"; };
+		50B63B332265BBE300CCB151 /* Defaults+RegisterDefaults.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Defaults+RegisterDefaults.swift"; sourceTree = "<group>"; };
 		63C197A55B797D98D9603C98 /* UserDefaults+PropertyList.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "UserDefaults+PropertyList.swift"; path = "Tests/SwiftyUserDefaultsTests/TestHelpers/UserDefaults+PropertyList.swift"; sourceTree = "<group>"; };
 		6494A812C2386E7351405E72 /* Defaults+URL.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Defaults+URL.swift"; path = "Tests/SwiftyUserDefaultsTests/Built-ins/Defaults+URL.swift"; sourceTree = "<group>"; };
 		6C48B95D407E4F720507F3D8 /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; name = Info.plist; path = Sources/Info.plist; sourceTree = "<group>"; };
@@ -122,6 +124,7 @@
 				85096B65E07A3BC7F856F0D1 /* OptionalType.swift */,
 				F98C7EF97445788836162CD0 /* DefaultsSerializable.swift */,
 				EE155E06F856DFEF78FD63F7 /* Defaults.swift */,
+				50B63B332265BBE300CCB151 /* Defaults+RegisterDefaults.swift */,
 			);
 			name = Sources;
 			sourceTree = "<group>";
@@ -264,6 +267,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 			);
 			mainGroup = 360E42BFF4D0B60A2966BBFB;
@@ -345,6 +349,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				50B63B342265BBE300CCB151 /* Defaults+RegisterDefaults.swift in Sources */,
 				D102C1011A4314AFF773DCD5 /* Defaults+StringToBool.swift in Sources */,
 				037280C1C6C68BDB8E3759E6 /* DefaultsKeys.swift in Sources */,
 				CC4CF6A63F6AA1B932D6757E /* DefaultsBridges.swift in Sources */,


### PR DESCRIPTION
I'm working on macOS apps and rely on the effect of `register(defaults:)` a lot. It didn't bother me to register them manually, using the swifty keys in the dictionary like so: `DefaultsKeys.myKey._key : 123`

But now that the keys require a default value, I'd like to not duplicate using this.

Either make the `defaultValue` public for compatibility, I figured, or offer a convenient wrapper around the `register(defaults:)` method. This is a prototype for the latter.

Is this a direction you want to go? 