### PR TITLE
[WIP] make more integer types DefaultsSerializable

### DIFF
--- a/Sources/DefaultsBridges.swift
+++ b/Sources/DefaultsBridges.swift
@@ -113,6 +113,26 @@ public final class DefaultsIntBridge: DefaultsBridge<Int> {
     }
 }
 
+public final class DefaultsUIntBridge: DefaultsBridge<UInt> {
+    public override func save(key: String, value: UInt?, userDefaults: UserDefaults) {
+        userDefaults.set(value, forKey: key)
+    }
+
+    public override func get(key: String, userDefaults: UserDefaults) -> UInt? {
+        if let int = userDefaults.number(forKey: key)?.uintValue {
+            return int
+        }
+
+        // Fallback for launch arguments
+        if let string = userDefaults.object(forKey: key) as? String,
+            let int = UInt(string) {
+            return int
+        }
+
+        return nil
+    }
+}
+
 public final class DefaultsDoubleBridge: DefaultsBridge<Double> {
     public override func save(key: String, value: Double?, userDefaults: UserDefaults) {
         userDefaults.set(value, forKey: key)

--- a/Sources/DefaultsSerializable+BuiltIns.swift
+++ b/Sources/DefaultsSerializable+BuiltIns.swift
@@ -39,6 +39,11 @@ extension Int: DefaultsSerializable {
     public static var _defaultsArray: DefaultsBridge<[Int]> { return DefaultsArrayBridge() }
 }
 
+extension UInt: DefaultsSerializable {
+    public static var _defaults: DefaultsBridge<UInt> { return DefaultsUIntBridge() }
+    public static var _defaultsArray: DefaultsBridge<[UInt]> { return DefaultsArrayBridge() }
+}
+
 extension Double: DefaultsSerializable {
     public static var _defaults: DefaultsBridge<Double> { return DefaultsDoubleBridge() }
     public static var _defaultsArray: DefaultsBridge<[Double]> { return DefaultsArrayBridge() }

--- a/SwiftyUserDefaults.xcodeproj/project.pbxproj
+++ b/SwiftyUserDefaults.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		311F24C3509BE924078AD67E /* DefaultsObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9701991125BC1345631E831E /* DefaultsObserver.swift */; };
 		499B0191487C22E03028ED3C /* Defaults+Int.swift in Sources */ = {isa = PBXBuildFile; fileRef = 041FE3F6B58F219CAAE0AD64 /* Defaults+Int.swift */; };
 		4B604921053C4F31217DCE9E /* Defaults+Observing.swift in Sources */ = {isa = PBXBuildFile; fileRef = F910BE3FABE99289E0545D95 /* Defaults+Observing.swift */; };
+		50B63B382265CE8E00CCB151 /* Defaults+UInt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50B63B372265CE8E00CCB151 /* Defaults+UInt.swift */; };
 		7EE5BB8911DFD47B6D6ED8E5 /* Defaults+Date.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F97C9DDE34857798EA6519B /* Defaults+Date.swift */; };
 		80C1C495919531D69B34BA6F /* Defaults+Data.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78703A0F180A4B7C450CD191 /* Defaults+Data.swift */; };
 		88573499C0B9C4F466D7EC2D /* DefaultsSerializable.swift in Sources */ = {isa = PBXBuildFile; fileRef = F98C7EF97445788836162CD0 /* DefaultsSerializable.swift */; };
@@ -55,6 +56,7 @@
 		2EFFE22277FA6C163E34F4D2 /* DefaultsSerializableSpec.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DefaultsSerializableSpec.swift; path = Tests/SwiftyUserDefaultsTests/TestHelpers/DefaultsSerializableSpec.swift; sourceTree = "<group>"; };
 		2F97C9DDE34857798EA6519B /* Defaults+Date.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Defaults+Date.swift"; path = "Tests/SwiftyUserDefaultsTests/Built-ins/Defaults+Date.swift"; sourceTree = "<group>"; };
 		3D8980553F1615D4ACB4AA43 /* Defaults+Dictionary.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Defaults+Dictionary.swift"; path = "Tests/SwiftyUserDefaultsTests/Built-ins/Defaults+Dictionary.swift"; sourceTree = "<group>"; };
+		50B63B372265CE8E00CCB151 /* Defaults+UInt.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "Defaults+UInt.swift"; path = "Tests/Defaults+UInt.swift"; sourceTree = "<group>"; };
 		63C197A55B797D98D9603C98 /* UserDefaults+PropertyList.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "UserDefaults+PropertyList.swift"; path = "Tests/SwiftyUserDefaultsTests/TestHelpers/UserDefaults+PropertyList.swift"; sourceTree = "<group>"; };
 		6494A812C2386E7351405E72 /* Defaults+URL.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Defaults+URL.swift"; path = "Tests/SwiftyUserDefaultsTests/Built-ins/Defaults+URL.swift"; sourceTree = "<group>"; };
 		6C48B95D407E4F720507F3D8 /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; name = Info.plist; path = Sources/Info.plist; sourceTree = "<group>"; };
@@ -163,12 +165,13 @@
 			children = (
 				6494A812C2386E7351405E72 /* Defaults+URL.swift */,
 				041FE3F6B58F219CAAE0AD64 /* Defaults+Int.swift */,
+				50B63B372265CE8E00CCB151 /* Defaults+UInt.swift */,
+				A574FF49CBCEBCCEAE9BD42E /* Defaults+String.swift */,
 				E57735ECA0C2F413E8EBC2E4 /* Defaults+Bool.swift */,
 				8790CE5B53F91DAD51975EDC /* Defaults+Double.swift */,
 				3D8980553F1615D4ACB4AA43 /* Defaults+Dictionary.swift */,
 				78703A0F180A4B7C450CD191 /* Defaults+Data.swift */,
 				2F97C9DDE34857798EA6519B /* Defaults+Date.swift */,
-				A574FF49CBCEBCCEAE9BD42E /* Defaults+String.swift */,
 			);
 			name = "Built-ins";
 			sourceTree = "<group>";
@@ -264,6 +267,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 			);
 			mainGroup = 360E42BFF4D0B60A2966BBFB;
@@ -322,6 +326,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				50B63B382265CE8E00CCB151 /* Defaults+UInt.swift in Sources */,
 				EA37551964DBE6344BC4178A /* Defaults+URL.swift in Sources */,
 				499B0191487C22E03028ED3C /* Defaults+Int.swift in Sources */,
 				89AF35E8D3CF0B18777540CC /* Defaults+Bool.swift in Sources */,

--- a/Tests/Defaults+UInt.swift
+++ b/Tests/Defaults+UInt.swift
@@ -1,0 +1,45 @@
+//
+// SwiftyUserDefaults
+//
+// Copyright (c) 2015-present Radosław Pietruszewski, Łukasz Mróz
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+
+import Quick
+
+final class DefaultsUIntSpec: QuickSpec, DefaultsSerializableSpec {
+    typealias Serializable = UInt
+
+    var customValue: UInt = 2
+    var defaultValue: UInt = 1
+
+    override func spec() {
+        given("UInt") {
+            self.testValues()
+            self.testOptionalValues()
+            self.testOptionalValuesWithoutDefaultValue()
+            self.testObserving()
+            self.testPlistRegisteringValues(valueStrings: ["0": UInt(0),
+                                                           "1": UInt(1),
+                                                           "2": UInt(2),
+                                                           "111111": UInt(111111)])
+        }
+    }
+}


### PR DESCRIPTION
I started with `UInt`, but the obvious next step would be to add Int64/32/16/8 and UInt64/32/16/8.

The code is pretty repetitive. In other projects, we used a code generator for this to prevent typos and code that's getting on one's nerves to maintain. But for 8 new types and their tests, we could stick with manual implementations just as well.

- Do you want to support the other types out of the box at all, anyway?
- Do you want manual or generated code?