### PR TITLE
make DefaultsKey.defaultValue publicly readable

### DIFF
--- a/Sources/DefaultsKeys.swift
+++ b/Sources/DefaultsKeys.swift
@@ -38,7 +38,7 @@ open class DefaultsKeys {
 open class DefaultsKey<ValueType: DefaultsSerializable>: DefaultsKeys {
 
     public let _key: String
-    internal let defaultValue: ValueType.T?
+    public let defaultValue: ValueType.T?
 
     public init(_ key: String, defaultValue: ValueType.T) {
         self._key = key


### PR DESCRIPTION
Should make 3rd party extensions like #165 easier, and implementations of `register(defaults:)` possible. Can precede #189 