### PR TITLE
KeyPath dynamicMemberLookup support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,7 +321,7 @@ Defaults.observe(key: nameKey, options: [.initial, .old, .new]) { _ in }
 
 ## Launch arguments
 
-Do you like to customize your app/script/tests by UserDefaults? Now it's fully supported on our side, statically typed of course. 
+Do you like to customize your app/script/tests by UserDefaults? Now it's fully supported on our side, statically typed of course.
 
 _Note: for now we support only `Bool`, `Double`, `Int`, `String` values, but if you have any other requests for that feature, please open an issue or PR and we can talk about implementing it in new versions._
 
@@ -364,6 +364,38 @@ var Defaults = UserDefaults(suiteName: "com.my.app")!
 If you want to check if we've got a value for `DefaultsKey`:
 ```swift
 let hasKey = Defaults.hasKey(.skipLogin)
+```
+
+## KeyPath dynamicMemberLookup
+
+SwiftyUserDefaults makes KeyPath dynamicMemberLookup usable in Swift 5.1!
+
+```swift
+extension DefaultsKeyStore {
+    var username: DefaultsKey<String?> { return .init("username") }
+    var launchCount: DefaultsKey<Int> { return .init("launchCount", defaultValue: 0) }
+}
+```
+
+And just use it ;-)
+
+```swift
+// Get and set user defaults easily
+let username = Defaults.username
+Defaults.hotkeyEnabled = true
+
+// Modify value types in place
+Defaults.launchCount += 1
+Defaults.volume -= 0.1
+Defaults.strings += "… can easily be extended!"
+
+// Use and modify typed arrays
+Defaults.libraries.append("SwiftyUserDefaults")
+Defaults.libraries[0] += " 2.0"
+
+// Easily work with custom serialized types
+Defaults.color = NSColor.white
+Defaults.color?.whiteComponent // => 1.0
 ```
 
 ## Installation

--- a/Sources/Defaults.swift
+++ b/Sources/Defaults.swift
@@ -29,20 +29,21 @@ import Foundation
 /// **Pro-Tip:** If you want to use shared user defaults, just
 ///  redefine this global shortcut in your app target, like so:
 ///  ~~~
-///  var Defaults = UserDefaults(suiteName: "com.my.app")!
+///  var Defaults = DefaultsAdapter(defaults: UserDefaults(suiteName: "com.my.app")!, keyStore: DefaultsKeyStore())
 ///  ~~~
 
-public let Defaults = UserDefaults.standard
+public let Defaults = DefaultsAdapter<DefaultsKeyStore>(defaults: .standard,
+                                                        keyStore: .init())
 
-public extension UserDefaults {
+extension UserDefaults: DefaultsType {
 
     /// Returns `true` if `key` exists
-    func hasKey<T>(_ key: DefaultsKey<T>) -> Bool {
+    public func hasKey<T>(_ key: DefaultsKey<T>) -> Bool {
         return object(forKey: key._key) != nil
     }
 
     /// Removes value for `key`
-    func remove<T>(_ key: DefaultsKey<T>) {
+    public func remove<T>(_ key: DefaultsKey<T>) {
         removeObject(forKey: key._key)
     }
 
@@ -50,7 +51,7 @@ public extension UserDefaults {
     /// Use with caution!
     /// - Note: This method only removes keys on the receiver `UserDefaults` object.
     ///         System-defined keys will still be present afterwards.
-    func removeAll() {
+    public func removeAll() {
         for (key, _) in dictionaryRepresentation() {
             removeObject(forKey: key)
         }

--- a/Sources/Defaults.swift
+++ b/Sources/Defaults.swift
@@ -69,7 +69,7 @@ internal extension UserDefaults {
 
         return try? JSONDecoder().decode(T.self, from: decodableData)
     }
-    
+
     /// Encodes passed `encodable` and saves the resulting data into the user defaults for the key `key`.
     /// Any error encoding will result in an assertion failure.
     func set<T: Encodable>(encodable: T, forKey key: String) {
@@ -79,5 +79,5 @@ internal extension UserDefaults {
         } catch {
             assertionFailure("Failure encoding encodable of type \(T.self): \(error.localizedDescription)")
         }
-    }    
+    }
 }

--- a/Sources/DefaultsAdapter.swift
+++ b/Sources/DefaultsAdapter.swift
@@ -24,14 +24,54 @@
 
 import Foundation
 
+/// A UserDefaults wrapper. It makes KeyPath dynamicMemberLookup  usable with UserDefaults in Swift 5.1 or greater.
+/// If Swift 5.0 or less, It works as ordinary SwiftyUserDefaults.
+///
+/// - seealso: https://github.com/apple/swift-evolution/blob/master/proposals/0252-keypath-dynamic-member-lookup.md
+///
+/// Here is a example:
+///
+/// ```
+/// extension DefaultsKeyStore {
+///     var launchCount: DefaultsKey<Int> {
+///         return .init("launchCount", defaultValue: 0)
+///     }
+/// }
+///
+/// Defaults.launchCount += 1
+/// ```
 @dynamicMemberLookup
 public final class DefaultsAdapter<KeyStore: DefaultsKeyStoreType> {
 
     #if swift(>=5.1)
+    /// A namespace for hasKey functions. It returns `Bool` when accesses with KeyPath dynamicMemberLookup.
+    ///
+    /// Here is example:
+    ///
+    /// ```
+    /// print(Defaults.hasKey.launchCount) // it returns true / false
+    /// ```
     public let hasKey: HasKey
+
+    /// A namespace for remove functions. It returns `() -> Void` when accesses with KeyPath dynamicMemberLookup.
+    ///
+    /// Here is exmaple:
+    ///
+    /// ```
+    /// Defaults.remove.launchCount()
+    /// ```
     public let remove: Remove
 
     #if !os(Linux)
+    /// A namespace for observe functions. It returns `(NSKeyValueObservingOptions, @escaping (DefaultsObserver<T>.Update) -> Void) -> DefaultsDisposable` when accesses with KeyPath dynamicMemberLookup.
+    ///
+    /// Here is exmaple:
+    ///
+    /// ```
+    /// let observer = Defaults.observe.launchCount([.old, .new]) { update in
+    ///     print(update)
+    /// }
+    /// ```
     public let observe: Observe
     #endif
 

--- a/Sources/DefaultsAdapter.swift
+++ b/Sources/DefaultsAdapter.swift
@@ -1,0 +1,213 @@
+//
+// SwiftyUserDefaults
+//
+// Copyright (c) 2015-present Radosław Pietruszewski, Łukasz Mróz
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+
+import Foundation
+
+@dynamicMemberLookup
+public final class DefaultsAdapter<KeyStore: DefaultsKeyStoreType> {
+
+    #if swift(>=5.1)
+    public let hasKey: HasKey
+    public let remove: Remove
+
+    #if !os(Linux)
+    public let observe: Observe
+    #endif
+
+    private let keyStore: KeyStore
+    #endif
+
+    private let defaults: UserDefaults
+
+    public init(defaults: UserDefaults, keyStore: KeyStore) {
+        self.defaults = defaults
+
+        #if swift(>=5.1)
+        self.keyStore = keyStore
+        let dependency = Dependency(defaults: defaults, keyStore: keyStore)
+
+        self.hasKey = HasKey(dependency)
+        self.remove = Remove(dependency)
+
+        #if !os(Linux)
+        self.observe = Observe(dependency)
+        #endif
+        #endif
+    }
+
+    @available(*, unavailable)
+    public subscript(dynamicMember member: String) -> Never {
+        fatalError()
+    }
+}
+
+extension DefaultsAdapter: DefaultsType {
+
+    public subscript<T>(key: DefaultsKey<T?>) -> T.T? where T : DefaultsSerializable {
+        get {
+            return defaults[key]
+        }
+        set {
+            defaults[key] = newValue
+        }
+    }
+
+    public subscript<T>(key: DefaultsKey<T>) -> T.T where T : DefaultsSerializable, T == T.T {
+        get {
+            return defaults[key]
+        }
+        set {
+            defaults[key] = newValue
+        }
+    }
+
+    public func hasKey<T>(_ key: DefaultsKey<T>) -> Bool where T : DefaultsSerializable {
+        return defaults.hasKey(key)
+    }
+
+    public func remove<T>(_ key: DefaultsKey<T>) where T : DefaultsSerializable {
+        defaults.remove(key)
+    }
+
+    public func removeAll() {
+        defaults.removeAll()
+    }
+
+    #if !os(Linux)
+    public func observe<T: DefaultsSerializable>(key: DefaultsKey<T>,
+                                                 options: NSKeyValueObservingOptions,
+                                                 handler: @escaping (DefaultsObserver<T>.Update) -> Void) -> DefaultsDisposable {
+        return defaults.observe(key: key, options: options, handler: handler)
+    }
+    #endif
+}
+
+#if swift(>=5.1)
+extension DefaultsAdapter {
+
+    public subscript<T: DefaultsSerializable>(dynamicMember keyPath: KeyPath<KeyStore, DefaultsKey<T?>>) -> T.T? {
+        get {
+            return defaults[keyStore[keyPath: keyPath]]
+        }
+        set {
+            defaults[keyStore[keyPath: keyPath]] = newValue
+        }
+    }
+
+    public subscript<T: DefaultsSerializable>(dynamicMember keyPath: KeyPath<KeyStore, DefaultsKey<T>>) -> T.T where T.T == T {
+        get {
+            return defaults[keyStore[keyPath: keyPath]]
+        }
+        set {
+            defaults[keyStore[keyPath: keyPath]] = newValue
+        }
+    }
+}
+
+extension DefaultsAdapter {
+
+    fileprivate final class Dependency {
+
+        let defaults: UserDefaults
+        let keyStore: KeyStore
+
+        init(defaults: UserDefaults, keyStore: KeyStore) {
+            self.defaults = defaults
+            self.keyStore = keyStore
+        }
+    }
+
+    @dynamicMemberLookup
+    public final class HasKey {
+        public typealias Root = KeyStore
+
+        fileprivate let dependency: Dependency
+
+        fileprivate init(_ dependency: Dependency) {
+            self.dependency = dependency
+        }
+    }
+
+    @dynamicMemberLookup
+    public final class Remove {
+        public typealias Root = KeyStore
+
+        fileprivate let dependency: Dependency
+
+        fileprivate init(_ dependency: Dependency) {
+            self.dependency = dependency
+        }
+    }
+
+    #if !os(Linux)
+    @dynamicMemberLookup
+    public final class Observe {
+        public typealias Root = KeyStore
+
+        fileprivate let dependency: Dependency
+
+        fileprivate init(_ dependency: Dependency) {
+            self.dependency = dependency
+        }
+    }
+    #endif
+}
+
+extension DefaultsAdapter.HasKey {
+
+    public subscript<T>(dynamicMember keyPath: KeyPath<Root, DefaultsKey<T>>) -> Bool {
+        return dependency.defaults.hasKey(dependency.keyStore[keyPath: keyPath])
+    }
+}
+
+extension DefaultsAdapter.Remove {
+
+    public subscript<T>(dynamicMember keyPath: KeyPath<Root, DefaultsKey<T>>) -> () -> Void {
+        return { [dependency] in
+            dependency.defaults.remove(dependency.keyStore[keyPath: keyPath])
+        }
+    }
+}
+
+#if !os(Linux)
+extension DefaultsAdapter.Observe {
+
+    public subscript<T>(dynamicMember keyPath: KeyPath<Root, DefaultsKey<T>>) -> (NSKeyValueObservingOptions, @escaping (DefaultsObserver<T>.Update) -> Void) -> DefaultsDisposable {
+        return { [dependency] options, handler  in
+            dependency.defaults.observe(key: dependency.keyStore[keyPath: keyPath],
+                                        options: options,
+                                        handler: handler)
+        }
+    }
+
+    public subscript<T>(dynamicMember keyPath: KeyPath<Root, DefaultsKey<T>>) -> (@escaping (DefaultsObserver<T>.Update) -> Void) -> DefaultsDisposable {
+        return { [dependency] handler  in
+            dependency.defaults.observe(key: dependency.keyStore[keyPath: keyPath],
+                                        options: [.old, .new],
+                                        handler: handler)
+        }
+    }
+}
+#endif
+#endif

--- a/Sources/DefaultsAdapter.swift
+++ b/Sources/DefaultsAdapter.swift
@@ -104,7 +104,7 @@ public final class DefaultsAdapter<KeyStore: DefaultsKeyStoreType> {
 
 extension DefaultsAdapter: DefaultsType {
 
-    public subscript<T>(key: DefaultsKey<T?>) -> T.T? where T : DefaultsSerializable {
+    public subscript<T: DefaultsSerializable>(key: DefaultsKey<T?>) -> T.T? {
         get {
             return defaults[key]
         }
@@ -113,7 +113,7 @@ extension DefaultsAdapter: DefaultsType {
         }
     }
 
-    public subscript<T>(key: DefaultsKey<T>) -> T.T where T : DefaultsSerializable, T == T.T {
+    public subscript<T: DefaultsSerializable>(key: DefaultsKey<T>) -> T.T where T == T.T {
         get {
             return defaults[key]
         }
@@ -122,11 +122,11 @@ extension DefaultsAdapter: DefaultsType {
         }
     }
 
-    public func hasKey<T>(_ key: DefaultsKey<T>) -> Bool where T : DefaultsSerializable {
+    public func hasKey<T: DefaultsSerializable>(_ key: DefaultsKey<T>) -> Bool {
         return defaults.hasKey(key)
     }
 
-    public func remove<T>(_ key: DefaultsKey<T>) where T : DefaultsSerializable {
+    public func remove<T: DefaultsSerializable>(_ key: DefaultsKey<T>) {
         defaults.remove(key)
     }
 
@@ -180,7 +180,6 @@ extension DefaultsAdapter {
 
     @dynamicMemberLookup
     public final class HasKey {
-        public typealias Root = KeyStore
 
         fileprivate let dependency: Dependency
 
@@ -191,7 +190,6 @@ extension DefaultsAdapter {
 
     @dynamicMemberLookup
     public final class Remove {
-        public typealias Root = KeyStore
 
         fileprivate let dependency: Dependency
 
@@ -203,7 +201,6 @@ extension DefaultsAdapter {
     #if !os(Linux)
     @dynamicMemberLookup
     public final class Observe {
-        public typealias Root = KeyStore
 
         fileprivate let dependency: Dependency
 
@@ -216,14 +213,14 @@ extension DefaultsAdapter {
 
 extension DefaultsAdapter.HasKey {
 
-    public subscript<T>(dynamicMember keyPath: KeyPath<Root, DefaultsKey<T>>) -> Bool {
+    public subscript<T>(dynamicMember keyPath: KeyPath<KeyStore, DefaultsKey<T>>) -> Bool {
         return dependency.defaults.hasKey(dependency.keyStore[keyPath: keyPath])
     }
 }
 
 extension DefaultsAdapter.Remove {
 
-    public subscript<T>(dynamicMember keyPath: KeyPath<Root, DefaultsKey<T>>) -> () -> Void {
+    public subscript<T>(dynamicMember keyPath: KeyPath<KeyStore, DefaultsKey<T>>) -> () -> Void {
         return { [dependency] in
             dependency.defaults.remove(dependency.keyStore[keyPath: keyPath])
         }
@@ -233,7 +230,7 @@ extension DefaultsAdapter.Remove {
 #if !os(Linux)
 extension DefaultsAdapter.Observe {
 
-    public subscript<T>(dynamicMember keyPath: KeyPath<Root, DefaultsKey<T>>) -> (NSKeyValueObservingOptions, @escaping (DefaultsObserver<T>.Update) -> Void) -> DefaultsDisposable {
+    public subscript<T>(dynamicMember keyPath: KeyPath<KeyStore, DefaultsKey<T>>) -> (NSKeyValueObservingOptions, @escaping (DefaultsObserver<T>.Update) -> Void) -> DefaultsDisposable {
         return { [dependency] options, handler  in
             dependency.defaults.observe(key: dependency.keyStore[keyPath: keyPath],
                                         options: options,
@@ -241,7 +238,7 @@ extension DefaultsAdapter.Observe {
         }
     }
 
-    public subscript<T>(dynamicMember keyPath: KeyPath<Root, DefaultsKey<T>>) -> (@escaping (DefaultsObserver<T>.Update) -> Void) -> DefaultsDisposable {
+    public subscript<T>(dynamicMember keyPath: KeyPath<KeyStore, DefaultsKey<T>>) -> (@escaping (DefaultsObserver<T>.Update) -> Void) -> DefaultsDisposable {
         return { [dependency] handler  in
             dependency.defaults.observe(key: dependency.keyStore[keyPath: keyPath],
                                         options: [.old, .new],

--- a/Sources/DefaultsKeyStore.swift
+++ b/Sources/DefaultsKeyStore.swift
@@ -1,0 +1,31 @@
+//
+// SwiftyUserDefaults
+//
+// Copyright (c) 2015-present Radosław Pietruszewski, Łukasz Mróz
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+
+import Foundation
+
+public protocol DefaultsKeyStoreType: AnyObject {}
+
+public final class DefaultsKeyStore: DefaultsKeyStoreType {
+    public init() {}
+}

--- a/Sources/DefaultsType.swift
+++ b/Sources/DefaultsType.swift
@@ -1,0 +1,48 @@
+//
+// SwiftyUserDefaults
+//
+// Copyright (c) 2015-present Radosław Pietruszewski, Łukasz Mróz
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+
+import Foundation
+
+public protocol DefaultsType {
+    func hasKey<T>(_ key: DefaultsKey<T>) -> Bool
+    func remove<T>(_ key: DefaultsKey<T>)
+    func removeAll()
+    subscript<T: DefaultsSerializable>(key: DefaultsKey<T?>) -> T.T? { get set }
+    subscript<T: DefaultsSerializable>(key: DefaultsKey<T>) -> T.T where T.T == T { get set }
+
+    #if !os(Linux)
+    func observe<T: DefaultsSerializable>(key: DefaultsKey<T>,
+                                          options: NSKeyValueObservingOptions,
+                                          handler: @escaping (DefaultsObserver<T>.Update) -> Void) -> DefaultsDisposable
+    #endif
+}
+
+#if !os(Linux)
+extension DefaultsType {
+    public func observe<T: DefaultsSerializable>(key: DefaultsKey<T>,
+                                                 handler: @escaping (DefaultsObserver<T>.Update) -> Void) -> DefaultsDisposable {
+        return observe(key: key, options: [.old, .new], handler: handler)
+    }
+}
+#endif

--- a/SwiftyUserDefaults.xcodeproj/project.pbxproj
+++ b/SwiftyUserDefaults.xcodeproj/project.pbxproj
@@ -32,6 +32,9 @@
 		CC4CF6A63F6AA1B932D6757E /* DefaultsBridges.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20EBA39F1E25782FDC1CFC36 /* DefaultsBridges.swift */; };
 		D102C1011A4314AFF773DCD5 /* Defaults+StringToBool.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11FDEA0BD7078D2633741F60 /* Defaults+StringToBool.swift */; };
 		EA37551964DBE6344BC4178A /* Defaults+URL.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6494A812C2386E7351405E72 /* Defaults+URL.swift */; };
+		ED39909122B0204E0046F502 /* DefaultsKeyStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED39909022B0204E0046F502 /* DefaultsKeyStore.swift */; };
+		ED9D95BF22AD74630006FE67 /* DefaultsAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED9D95BD22AD74630006FE67 /* DefaultsAdapter.swift */; };
+		ED9D95C022AD74630006FE67 /* DefaultsType.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED9D95BE22AD74630006FE67 /* DefaultsType.swift */; };
 		F0340276AF034C710E8C81A7 /* DefaultsSerializable+BuiltIns.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB55DC75BF69CEA7DB03750E /* DefaultsSerializable+BuiltIns.swift */; };
 		F73433D64DE45C8219A51BED /* Defaults+BestFroggiesEnum.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5A5BEEC51B2A01157F9965F /* Defaults+BestFroggiesEnum.swift */; };
 /* End PBXBuildFile section */
@@ -71,6 +74,9 @@
 		CBE434F1CEE20652BC414284 /* Defaults+FrogCodable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Defaults+FrogCodable.swift"; path = "Tests/SwiftyUserDefaultsTests/External types/Defaults+FrogCodable.swift"; sourceTree = "<group>"; };
 		D0EE0402DB7DB637D79FEC2B /* TestHelper.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = TestHelper.swift; path = Tests/SwiftyUserDefaultsTests/TestHelpers/TestHelper.swift; sourceTree = "<group>"; };
 		E57735ECA0C2F413E8EBC2E4 /* Defaults+Bool.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Defaults+Bool.swift"; path = "Tests/SwiftyUserDefaultsTests/Built-ins/Defaults+Bool.swift"; sourceTree = "<group>"; };
+		ED39909022B0204E0046F502 /* DefaultsKeyStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = DefaultsKeyStore.swift; path = Sources/DefaultsKeyStore.swift; sourceTree = "<group>"; };
+		ED9D95BD22AD74630006FE67 /* DefaultsAdapter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = DefaultsAdapter.swift; path = Sources/DefaultsAdapter.swift; sourceTree = "<group>"; };
+		ED9D95BE22AD74630006FE67 /* DefaultsType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = DefaultsType.swift; path = Sources/DefaultsType.swift; sourceTree = "<group>"; };
 		EE155E06F856DFEF78FD63F7 /* Defaults.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Defaults.swift; path = Sources/Defaults.swift; sourceTree = "<group>"; };
 		F067CFEA88F84E726E835422 /* SwiftyUserDefaultsTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SwiftyUserDefaultsTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		F15D6CCB785C552A0B39B16A /* Defaults+Color.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Defaults+Color.swift"; path = "Tests/SwiftyUserDefaultsTests/External types/Defaults+Color.swift"; sourceTree = "<group>"; };
@@ -122,6 +128,9 @@
 				85096B65E07A3BC7F856F0D1 /* OptionalType.swift */,
 				F98C7EF97445788836162CD0 /* DefaultsSerializable.swift */,
 				EE155E06F856DFEF78FD63F7 /* Defaults.swift */,
+				ED9D95BD22AD74630006FE67 /* DefaultsAdapter.swift */,
+				ED9D95BE22AD74630006FE67 /* DefaultsType.swift */,
+				ED39909022B0204E0046F502 /* DefaultsKeyStore.swift */,
 			);
 			name = Sources;
 			sourceTree = "<group>";
@@ -264,6 +273,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 			);
 			mainGroup = 360E42BFF4D0B60A2966BBFB;
@@ -348,11 +358,14 @@
 				D102C1011A4314AFF773DCD5 /* Defaults+StringToBool.swift in Sources */,
 				037280C1C6C68BDB8E3759E6 /* DefaultsKeys.swift in Sources */,
 				CC4CF6A63F6AA1B932D6757E /* DefaultsBridges.swift in Sources */,
+				ED39909122B0204E0046F502 /* DefaultsKeyStore.swift in Sources */,
+				ED9D95C022AD74630006FE67 /* DefaultsType.swift in Sources */,
 				A3CAE6734DDE8FD952CE2CF2 /* Defaults+Subscripts.swift in Sources */,
 				4B604921053C4F31217DCE9E /* Defaults+Observing.swift in Sources */,
 				311F24C3509BE924078AD67E /* DefaultsObserver.swift in Sources */,
 				F0340276AF034C710E8C81A7 /* DefaultsSerializable+BuiltIns.swift in Sources */,
 				1C21A8A584B33AF419FCE1A5 /* OptionalType.swift in Sources */,
+				ED9D95BF22AD74630006FE67 /* DefaultsAdapter.swift in Sources */,
 				88573499C0B9C4F466D7EC2D /* DefaultsSerializable.swift in Sources */,
 				9FA427F1D84703CE8EC6CD38 /* Defaults.swift in Sources */,
 			);

--- a/Tests/SwiftyUserDefaultsTests/Built-ins/Defaults+Bool.swift
+++ b/Tests/SwiftyUserDefaultsTests/Built-ins/Defaults+Bool.swift
@@ -30,6 +30,7 @@ final class DefaultsBoolSpec: QuickSpec, DefaultsSerializableSpec {
 
     var customValue: Bool = true
     var defaultValue: Bool = false
+    var keyStore = FrogKeyStore<Serializable>()
 
     override func spec() {
         given("Bool") {

--- a/Tests/SwiftyUserDefaultsTests/Built-ins/Defaults+Data.swift
+++ b/Tests/SwiftyUserDefaultsTests/Built-ins/Defaults+Data.swift
@@ -31,6 +31,7 @@ final class DefaultsDataSpec: QuickSpec, DefaultsSerializableSpec {
 
     var customValue: Data = "custom data".data(using: .utf8)!
     var defaultValue: Data = "default data".data(using: .utf8)!
+    var keyStore = FrogKeyStore<Serializable>()
 
     override func spec() {
         given("Data") {

--- a/Tests/SwiftyUserDefaultsTests/Built-ins/Defaults+Date.swift
+++ b/Tests/SwiftyUserDefaultsTests/Built-ins/Defaults+Date.swift
@@ -31,6 +31,7 @@ final class DefaultsDateSpec: QuickSpec, DefaultsSerializableSpec {
 
     var customValue: Date = Date(timeIntervalSince1970: 50)
     var defaultValue: Date = Date()
+    var keyStore = FrogKeyStore<Serializable>()
 
     override func spec() {
         given("Date") {

--- a/Tests/SwiftyUserDefaultsTests/Built-ins/Defaults+Dictionary.swift
+++ b/Tests/SwiftyUserDefaultsTests/Built-ins/Defaults+Dictionary.swift
@@ -31,6 +31,7 @@ final class DefaultsDictionarySpec: QuickSpec, DefaultsSerializableSpec {
 
     var customValue: [String: AnyHashable] = ["a": "b"]
     var defaultValue: [String: AnyHashable] = ["c": "d", "e": 1]
+    var keyStore = FrogKeyStore<Serializable>()
 
     override func spec() {
         given("Dictionary") {

--- a/Tests/SwiftyUserDefaultsTests/Built-ins/Defaults+Double.swift
+++ b/Tests/SwiftyUserDefaultsTests/Built-ins/Defaults+Double.swift
@@ -30,6 +30,7 @@ final class DefaultsDoubleSpec: QuickSpec, DefaultsSerializableSpec {
 
     var customValue: Double = 2.0
     var defaultValue: Double = 1.0
+    var keyStore = FrogKeyStore<Serializable>()
 
     override func spec() {
         given("Double") {

--- a/Tests/SwiftyUserDefaultsTests/Built-ins/Defaults+Int.swift
+++ b/Tests/SwiftyUserDefaultsTests/Built-ins/Defaults+Int.swift
@@ -25,10 +25,12 @@
 import Quick
 
 final class DefaultsIntSpec: QuickSpec, DefaultsSerializableSpec {
+
     typealias Serializable = Int
 
     var customValue: Int = 2
     var defaultValue: Int = 1
+    var keyStore = FrogKeyStore<Serializable>()
 
     override func spec() {
         given("Int") {

--- a/Tests/SwiftyUserDefaultsTests/Built-ins/Defaults+String.swift
+++ b/Tests/SwiftyUserDefaultsTests/Built-ins/Defaults+String.swift
@@ -30,6 +30,7 @@ final class DefaultsStringSpec: QuickSpec, DefaultsSerializableSpec {
 
     var customValue: String = "custom value"
     var defaultValue: String = "default value"
+    var keyStore = FrogKeyStore<Serializable>()
 
     override func spec() {
         given("String") {

--- a/Tests/SwiftyUserDefaultsTests/Built-ins/Defaults+URL.swift
+++ b/Tests/SwiftyUserDefaultsTests/Built-ins/Defaults+URL.swift
@@ -31,6 +31,7 @@ final class DefaultsUrlSpec: QuickSpec, DefaultsSerializableSpec {
 
     var customValue: URL = URL(string: "https://google.com")!
     var defaultValue: URL = URL(string: "https://github.com")!
+    var keyStore = FrogKeyStore<Serializable>()
 
     override func spec() {
         given("URL") {

--- a/Tests/SwiftyUserDefaultsTests/External types/Defaults+BestFroggiesEnum.swift
+++ b/Tests/SwiftyUserDefaultsTests/External types/Defaults+BestFroggiesEnum.swift
@@ -30,6 +30,7 @@ final class DefaultsBestFroggiesEnumSerializableSpec: QuickSpec, DefaultsSeriali
 
     var customValue: BestFroggiesEnum = .Andy
     var defaultValue: BestFroggiesEnum = .Dandy
+    var keyStore = FrogKeyStore<Serializable>()
 
     override func spec() {
         given("BestFroggiesEnum") {

--- a/Tests/SwiftyUserDefaultsTests/External types/Defaults+Color.swift
+++ b/Tests/SwiftyUserDefaultsTests/External types/Defaults+Color.swift
@@ -43,6 +43,7 @@ final class DefaultsUIColorSerializableSpec: QuickSpec, DefaultsSerializableSpec
 
     var customValue: Color = .green
     var defaultValue: Color = .blue
+    var keyStore = FrogKeyStore<Serializable>()
 
     override func spec() {
         given("NSColor") {

--- a/Tests/SwiftyUserDefaultsTests/External types/Defaults+FrogCodable.swift
+++ b/Tests/SwiftyUserDefaultsTests/External types/Defaults+FrogCodable.swift
@@ -30,6 +30,7 @@ final class DefaultsFrogCodableSpec: QuickSpec, DefaultsSerializableSpec {
 
     var customValue: FrogCodable = FrogCodable(name: "custom")
     var defaultValue: FrogCodable = FrogCodable(name: "default")
+    var keyStore = FrogKeyStore<Serializable>()
 
     override func spec() {
         given("FrogCodable") {

--- a/Tests/SwiftyUserDefaultsTests/External types/Defaults+FrogCustomSerializable.swift
+++ b/Tests/SwiftyUserDefaultsTests/External types/Defaults+FrogCustomSerializable.swift
@@ -30,6 +30,7 @@ final class DefaultsFrogCustomSerializableSpec: QuickSpec, DefaultsSerializableS
 
     var customValue: FrogCustomSerializable = FrogCustomSerializable(name: "custom")
     var defaultValue: FrogCustomSerializable = FrogCustomSerializable(name: "default")
+    var keyStore = FrogKeyStore<Serializable>()
 
     override func spec() {
         given("FrogCustomSerializable") {

--- a/Tests/SwiftyUserDefaultsTests/External types/Defaults+FrogSerializable.swift
+++ b/Tests/SwiftyUserDefaultsTests/External types/Defaults+FrogSerializable.swift
@@ -30,6 +30,7 @@ final class DefaultsFrogSerializableSpec: QuickSpec, DefaultsSerializableSpec {
 
     var customValue: FrogSerializable = FrogSerializable(name: "custom")
     var defaultValue: FrogSerializable = FrogSerializable(name: "default")
+    var keyStore = FrogKeyStore<Serializable>()
 
     override func spec() {
         given("FrogSerializable") {

--- a/Tests/SwiftyUserDefaultsTests/TestHelpers/DefaultsSerializableSpec.swift
+++ b/Tests/SwiftyUserDefaultsTests/TestHelpers/DefaultsSerializableSpec.swift
@@ -32,17 +32,22 @@ protocol DefaultsSerializableSpec {
 
     var defaultValue: Serializable.T { get }
     var customValue: Serializable.T { get }
+    var keyStore: FrogKeyStore<Serializable> { get }
 }
 
 extension DefaultsSerializableSpec where Serializable.T: Equatable, Serializable.T == Serializable {
 
     func testValues() {
         when("key-default value") {
-            var defaults: UserDefaults!
+            var defaults: DefaultsAdapter<FrogKeyStore<Serializable>>!
+            var removeObject: ((String) -> Void)!
 
             beforeEach {
-                defaults = UserDefaults()
-                defaults.cleanObjects()
+                let userDefaults = UserDefaults()
+                defaults = DefaultsAdapter(defaults: userDefaults,
+                                           keyStore: self.keyStore)
+                userDefaults.cleanObjects()
+                removeObject = userDefaults.removeObject
             }
 
             then("create a key") {
@@ -63,11 +68,27 @@ extension DefaultsSerializableSpec where Serializable.T: Equatable, Serializable
                 expect(value) == self.defaultValue
             }
 
+            #if swift(>=5.1)
+            then("get a default value with dynamicMemberLookup") {
+                self.keyStore.testValue = DefaultsKey<Serializable>("test", defaultValue: self.defaultValue)
+                let value = defaults.testValue
+                expect(value) == self.defaultValue
+            }
+            #endif
+
             then("get a default array value") {
                 let key = DefaultsKey<[Serializable]>("test", defaultValue: [self.defaultValue])
                 let value = defaults[key]
                 expect(value) == [self.defaultValue]
             }
+
+            #if swift(>=5.1)
+            then("get a default array value with dynamicMemberLookup") {
+                self.keyStore.testArray = DefaultsKey<[Serializable]>("test", defaultValue: [self.defaultValue])
+                let value = defaults.testArray
+                expect(value) == [self.defaultValue]
+            }
+            #endif
 
             then("save a value") {
                 let key = DefaultsKey<Serializable>("test", defaultValue: self.defaultValue)
@@ -79,6 +100,18 @@ extension DefaultsSerializableSpec where Serializable.T: Equatable, Serializable
                 expect(value) == expectedValue
             }
 
+            #if swift(>=5.1)
+            then("save a value with dynamicMemberLookup") {
+                self.keyStore.testValue = DefaultsKey<Serializable>("test", defaultValue: self.defaultValue)
+                let expectedValue = self.customValue
+                defaults.testValue = expectedValue
+
+                let value = defaults.testValue
+
+                expect(value) == expectedValue
+            }
+            #endif
+
             then("save an array value") {
                 let key = DefaultsKey<[Serializable]>("test", defaultValue: [self.defaultValue])
                 let expectedValue = [self.customValue]
@@ -88,34 +121,72 @@ extension DefaultsSerializableSpec where Serializable.T: Equatable, Serializable
 
                 expect(value) == expectedValue
             }
+
+            #if swift(>=5.1)
+            then("save an array value with dynamicMemberLookup") {
+                self.keyStore.testArray = DefaultsKey<[Serializable]>("test", defaultValue: [self.defaultValue])
+                let expectedValue = [self.customValue]
+                defaults.testArray = expectedValue
+
+                let value = defaults.testArray
+
+                expect(value) == expectedValue
+            }
+            #endif
 
             then("remove a value") {
                 let key = DefaultsKey<Serializable>("test", defaultValue: self.defaultValue)
                 defaults[key] = self.customValue
 
-                defaults.removeObject(forKey: "test")
+                removeObject("test")
 
                 expect(defaults[key]) == self.defaultValue
             }
+
+            #if swift(>=5.1)
+            then("remove a value with dynamicMemberLookup") {
+                self.keyStore.testValue = DefaultsKey<Serializable>("test", defaultValue: self.defaultValue)
+                defaults.testValue = self.customValue
+
+                defaults.remove.testValue()
+
+                expect(defaults.hasKey.testValue) == false
+                expect(defaults.testValue) == self.defaultValue
+            }
+            #endif
 
             then("remove an array value") {
                 let key = DefaultsKey<[Serializable]?>("test", defaultValue: [self.defaultValue])
                 defaults[key] = [self.customValue]
 
-                defaults.removeObject(forKey: "test")
+                removeObject("test")
 
                 expect(defaults[key]) == [self.defaultValue]
             }
+
+            #if swift(>=5.1)
+            then("remove an array value with dynamicMemberLookup") {
+                self.keyStore.testOptionalArray = DefaultsKey<[Serializable]?>("test", defaultValue: [self.defaultValue])
+                defaults.testOptionalArray = [self.customValue]
+
+                defaults.remove.testOptionalArray()
+
+                expect(defaults.hasKey.testOptionalArray) == false
+                expect(defaults.testOptionalArray) == [self.defaultValue]
+            }
+            #endif
         }
     }
 
     func testOptionalValues() {
         when("key-default optional value") {
-            var defaults: UserDefaults!
+            var defaults: DefaultsAdapter<FrogKeyStore<Serializable>>!
 
             beforeEach {
-                defaults = UserDefaults()
-                defaults.cleanObjects()
+                let userDefaults = UserDefaults()
+                defaults = DefaultsAdapter(defaults: userDefaults,
+                                           keyStore: self.keyStore)
+                userDefaults.cleanObjects()
             }
 
             then("create a key") {
@@ -136,11 +207,27 @@ extension DefaultsSerializableSpec where Serializable.T: Equatable, Serializable
                 expect(value) == self.defaultValue
             }
 
+            #if swift(>=5.1)
+            then("get a default value with dynamicMemberLookup") {
+                self.keyStore.testOptionalValue = DefaultsKey<Serializable?>("test", defaultValue: self.defaultValue)
+                let value = defaults.testOptionalValue
+                expect(value) == self.defaultValue
+            }
+            #endif
+
             then("get a default array value") {
                 let key = DefaultsKey<[Serializable]?>("test", defaultValue: [self.defaultValue])
                 let value = defaults[key]
                 expect(value) == [self.defaultValue]
             }
+
+            #if swift(>=5.1)
+            then("get a default array value with dynamicMemberLookup") {
+                self.keyStore.testOptionalArray = DefaultsKey<[Serializable]?>("test", defaultValue: [self.defaultValue])
+                let value = defaults.testOptionalArray
+                expect(value) == [self.defaultValue]
+            }
+            #endif
 
             then("save a value") {
                 let key = DefaultsKey<Serializable?>("test", defaultValue: self.defaultValue)
@@ -152,6 +239,18 @@ extension DefaultsSerializableSpec where Serializable.T: Equatable, Serializable
                 expect(value) == expectedValue
             }
 
+            #if swift(>=5.1)
+            then("save a value with dynamicMemberLookup") {
+                self.keyStore.testOptionalValue = DefaultsKey<Serializable?>("test", defaultValue: self.defaultValue)
+                let expectedValue = self.customValue
+                defaults.testOptionalValue = expectedValue
+
+                let value = defaults.testOptionalValue
+
+                expect(value) == expectedValue
+            }
+            #endif
+
             then("save an array value") {
                 let key = DefaultsKey<[Serializable]?>("test", defaultValue: [self.defaultValue])
                 let expectedValue = [self.customValue]
@@ -162,6 +261,18 @@ extension DefaultsSerializableSpec where Serializable.T: Equatable, Serializable
                 expect(value) == expectedValue
             }
 
+            #if swift(>=5.1)
+            then("save an array value with dynamicMemberLookup") {
+                self.keyStore.testOptionalArray = DefaultsKey<[Serializable]?>("test", defaultValue: [self.defaultValue])
+                let expectedValue = [self.customValue]
+                defaults.testOptionalArray = expectedValue
+
+                let value = defaults.testOptionalArray
+
+                expect(value) == expectedValue
+            }
+            #endif
+
             then("remove a value") {
                 let key = DefaultsKey<Serializable?>("test", defaultValue: self.defaultValue)
 
@@ -170,6 +281,16 @@ extension DefaultsSerializableSpec where Serializable.T: Equatable, Serializable
                 expect(defaults[key]) == self.defaultValue
             }
 
+            #if swift(>=5.1)
+            then("remove a value with dynamicMemberLookup") {
+                self.keyStore.testOptionalValue = DefaultsKey<Serializable?>("test", defaultValue: self.defaultValue)
+
+                defaults.testOptionalValue = nil
+
+                expect(defaults.testOptionalValue) == self.defaultValue
+            }
+            #endif
+
             then("remove an array value") {
                 let key = DefaultsKey<[Serializable]?>("test", defaultValue: [self.defaultValue])
 
@@ -177,16 +298,28 @@ extension DefaultsSerializableSpec where Serializable.T: Equatable, Serializable
 
                 expect(defaults[key]) == [self.defaultValue]
             }
+
+            #if swift(>=5.1)
+            then("remove an array value with dynamicMemberLookup") {
+                self.keyStore.testOptionalArray = DefaultsKey<[Serializable]?>("test", defaultValue: [self.defaultValue])
+
+                defaults.testOptionalArray = nil
+
+                expect(defaults.testOptionalArray) == [self.defaultValue]
+            }
+            #endif
         }
     }
 
     func testOptionalValuesWithoutDefaultValue() {
         when("key-nil optional value") {
-            var defaults: UserDefaults!
+            var defaults: DefaultsAdapter<FrogKeyStore<Serializable>>!
 
             beforeEach {
-                defaults = UserDefaults()
-                defaults.cleanObjects()
+                let userDefaults = UserDefaults()
+                defaults = DefaultsAdapter(defaults: userDefaults,
+                                           keyStore: self.keyStore)
+                userDefaults.cleanObjects()
             }
 
             then("create a key") {
@@ -211,6 +344,18 @@ extension DefaultsSerializableSpec where Serializable.T: Equatable, Serializable
                 expect(value) == expectedValue
             }
 
+            #if swift(>=5.1)
+            then("save a value with dynamicMemberLookup") {
+                self.keyStore.testOptionalValue = DefaultsKey<Serializable?>("test")
+                let expectedValue = self.customValue
+                defaults.testOptionalValue = expectedValue
+
+                let value = defaults.testOptionalValue
+
+                expect(value) == expectedValue
+            }
+            #endif
+
             then("save an array value") {
                 let key = DefaultsKey<[Serializable]?>("test")
                 let expectedValue = [self.customValue]
@@ -220,6 +365,18 @@ extension DefaultsSerializableSpec where Serializable.T: Equatable, Serializable
 
                 expect(value) == expectedValue
             }
+
+            #if swift(>=5.1)
+            then("save an array value with dynamicMemberLookup") {
+                self.keyStore.testOptionalArray = DefaultsKey<[Serializable]?>("test")
+                let expectedValue = [self.customValue]
+                defaults.testOptionalArray = expectedValue
+
+                let value = defaults.testOptionalArray
+
+                expect(value) == expectedValue
+            }
+            #endif
 
             then("remove a value") {
                 let key = DefaultsKey<Serializable?>("test")
@@ -231,6 +388,18 @@ extension DefaultsSerializableSpec where Serializable.T: Equatable, Serializable
                 expect(defaults[key]).to(beNil())
             }
 
+            #if swift(>=5.1)
+            then("remove a value with dynamicMemberLookup") {
+                self.keyStore.testOptionalValue = DefaultsKey<Serializable?>("test")
+
+                defaults.testOptionalValue = self.defaultValue
+                expect(defaults.testOptionalValue) == self.defaultValue
+
+                defaults.testOptionalValue = nil
+                expect(defaults.testOptionalValue).to(beNil())
+            }
+            #endif
+
             then("remove an array value") {
                 let key = DefaultsKey<[Serializable]?>("test")
 
@@ -241,11 +410,31 @@ extension DefaultsSerializableSpec where Serializable.T: Equatable, Serializable
                 expect(defaults[key]).to(beNil())
             }
 
+            #if swift(>=5.1)
+            then("remove an array with dynamicMemberLookup") {
+                self.keyStore.testOptionalArray = DefaultsKey<[Serializable]?>("test")
+
+                defaults.testOptionalArray = [self.defaultValue]
+                expect(defaults.testOptionalArray) == [self.defaultValue]
+
+                defaults.testOptionalArray = nil
+                expect(defaults.testOptionalArray).to(beNil())
+            }
+            #endif
+
             then("compare optional value to non-optional value") {
                 let key = DefaultsKey<Serializable?>("test")
                 expect(defaults[key] == nil).to(beTrue())
                 expect(defaults[key] != self.defaultValue).to(beTrue())
             }
+
+            #if swift(>=5.1)
+            then("compare optional value to non-optional value with dynamicMemberLookup") {
+                self.keyStore.testOptionalValue = DefaultsKey<Serializable?>("test")
+                expect(defaults.testOptionalValue == nil).to(beTrue())
+                expect(defaults.testOptionalValue != self.defaultValue).to(beTrue())
+            }
+            #endif
         }
     }
 
@@ -254,12 +443,14 @@ extension DefaultsSerializableSpec where Serializable.T: Equatable, Serializable
         let enumeratedArguments = valueStrings.enumerated()
 
         given("plist-registered values") {
-            var defaults: UserDefaults!
+            var defaults: DefaultsAdapter<FrogKeyStore<Serializable>>!
 
             beforeEach {
                 let suiteName = UUID().uuidString
-                defaults = UserDefaults(suiteName: suiteName)
-                injectPlistArguments(to: defaults)
+                let userDefaults = UserDefaults(suiteName: suiteName)!
+                defaults = DefaultsAdapter(defaults: userDefaults,
+                                           keyStore: self.keyStore)
+                injectPlistArguments(to: userDefaults)
             }
 
             then("read values to non-optional keys") {
@@ -333,11 +524,13 @@ extension DefaultsSerializableSpec where Serializable.T: Equatable, Serializable
     func testObserving() {
         #if !os(Linux)
         given("key-value observing") {
-            var defaults: UserDefaults!
+            var defaults: DefaultsAdapter<FrogKeyStore<Serializable>>!
 
             beforeEach {
                 let suiteName = UUID().uuidString
-                defaults = UserDefaults(suiteName: suiteName)
+                let userDefaults = UserDefaults(suiteName: suiteName)!
+                defaults = DefaultsAdapter(defaults: userDefaults,
+                                           keyStore: self.keyStore)
             }
 
             when("optional key without default value") {
@@ -355,6 +548,22 @@ extension DefaultsSerializableSpec where Serializable.T: Equatable, Serializable
                     expect(update?.newValue).toEventually(equal(self.customValue))
                 }
 
+                #if swift(>=5.1)
+                then("receive updates with dynamicMemberLookup") {
+                    self.keyStore.testOptionalValue = DefaultsKey<Serializable?>("test")
+
+                    var update: DefaultsObserver<Serializable?>.Update?
+                    let observer = defaults.observe.testOptionalValue { receivedUpdate in
+                        update = receivedUpdate
+                    }
+
+                    defaults.testOptionalValue = self.customValue
+
+                    expect(update?.oldValue).toEventually(beNil())
+                    expect(update?.newValue).toEventually(equal(self.customValue))
+                }
+                #endif
+
                 then("receives initial update") {
                     let key = DefaultsKey<Serializable?>("test")
 
@@ -367,6 +576,21 @@ extension DefaultsSerializableSpec where Serializable.T: Equatable, Serializable
                     expect(update?.oldValue).toEventually(beNil())
                     expect(update?.newValue).toEventually(beNil())
                 }
+
+                #if swift(>=5.1)
+                then("receives initial update with dynamicMemberLookup") {
+                    self.keyStore.testOptionalValue = DefaultsKey<Serializable?>("test")
+
+                    var update: DefaultsObserver<Serializable?>.Update?
+                    let observer = defaults.observe.testOptionalValue([.initial, .old, .new]) { receivedUpdate in
+                        update = receivedUpdate
+                    }
+
+                    expect(update).toEventuallyNot(beNil())
+                    expect(update?.oldValue).toEventually(beNil())
+                    expect(update?.newValue).toEventually(beNil())
+                }
+                #endif
 
                 then("receives nil update") {
                     let key = DefaultsKey<Serializable?>("test")
@@ -383,6 +607,23 @@ extension DefaultsSerializableSpec where Serializable.T: Equatable, Serializable
                     expect(update?.newValue).toEventually(beNil())
                 }
 
+                #if swift(>=5.1)
+                then("receives nil update with dynamicMemberLookup") {
+                    self.keyStore.testOptionalValue = DefaultsKey<Serializable?>("test")
+
+                    var update: DefaultsObserver<Serializable?>.Update?
+                    let observer = defaults.observe.testOptionalValue { receivedUpdate in
+                        update = receivedUpdate
+                    }
+                    defaults.testOptionalValue = self.defaultValue
+                    defaults.testOptionalValue = nil
+
+                    expect(update).toEventuallyNot(beNil())
+                    expect(update?.oldValue).toEventually(equal(self.defaultValue))
+                    expect(update?.newValue).toEventually(beNil())
+                }
+                #endif
+
                 then("remove observer on dispose") {
                     let key = DefaultsKey<Serializable?>("test")
 
@@ -397,6 +638,23 @@ extension DefaultsSerializableSpec where Serializable.T: Equatable, Serializable
                     expect(update?.oldValue).toEventually(beNil())
                     expect(update?.newValue).toEventually(beNil())
                 }
+
+                #if swift(>=5.1)
+                then("remove observer on dispose with dynamicMemberLookup") {
+                    self.keyStore.testOptionalValue = DefaultsKey<Serializable?>("test")
+
+                    var update: DefaultsObserver<Serializable?>.Update?
+                    let observer = defaults.observe.testOptionalValue { receivedUpdate in
+                        update = receivedUpdate
+                    }
+
+                    observer.dispose()
+                    defaults.testOptionalValue = self.customValue
+
+                    expect(update?.oldValue).toEventually(beNil())
+                    expect(update?.newValue).toEventually(beNil())
+                }
+                #endif
             }
 
             when("optional key with default value") {
@@ -414,6 +672,22 @@ extension DefaultsSerializableSpec where Serializable.T: Equatable, Serializable
                     expect(update?.newValue).toEventually(equal(self.customValue))
                 }
 
+                #if swift(>=5.1)
+                then("receive updates with dynamicMemberLookup") {
+                    self.keyStore.testOptionalValue = DefaultsKey<Serializable?>("test", defaultValue: self.defaultValue)
+
+                    var update: DefaultsObserver<Serializable?>.Update?
+                    let observer = defaults.observe.testOptionalValue { receivedUpdate in
+                        update = receivedUpdate
+                    }
+
+                    defaults.testOptionalValue = self.customValue
+
+                    expect(update?.oldValue).toEventually(equal(self.defaultValue))
+                    expect(update?.newValue).toEventually(equal(self.customValue))
+                }
+                #endif
+
                 then("receives initial update") {
                     let key = DefaultsKey<Serializable?>("test", defaultValue: self.defaultValue)
 
@@ -425,6 +699,20 @@ extension DefaultsSerializableSpec where Serializable.T: Equatable, Serializable
                     expect(update?.oldValue).toEventually(equal(self.defaultValue))
                     expect(update?.newValue).toEventually(equal(self.defaultValue))
                 }
+
+                #if swift(>=5.1)
+                then("receives initial update with dynamicMemberLookup") {
+                    self.keyStore.testOptionalValue = DefaultsKey<Serializable?>("test", defaultValue: self.defaultValue)
+
+                    var update: DefaultsObserver<Serializable?>.Update?
+                    let observer = defaults.observe.testOptionalValue([.initial, .old, .new]) { receivedUpdate in
+                        update = receivedUpdate
+                    }
+
+                    expect(update?.oldValue).toEventually(equal(self.defaultValue))
+                    expect(update?.newValue).toEventually(equal(self.defaultValue))
+                }
+                #endif
 
                 then("receives nil update") {
                     let key = DefaultsKey<Serializable?>("test", defaultValue: self.defaultValue)
@@ -441,6 +729,23 @@ extension DefaultsSerializableSpec where Serializable.T: Equatable, Serializable
                     expect(update?.newValue).toEventually(equal(self.defaultValue))
                 }
 
+                #if swift(>=5.1)
+                then("receives nil update with dynamicMemberLookup") {
+                    self.keyStore.testOptionalValue = DefaultsKey<Serializable?>("test", defaultValue: self.defaultValue)
+
+                    var update: DefaultsObserver<Serializable?>.Update?
+                    let observer = defaults.observe.testOptionalValue { receivedUpdate in
+                        update = receivedUpdate
+                    }
+                    defaults.testOptionalValue = self.defaultValue
+                    defaults.testOptionalValue = nil
+
+                    expect(update).toEventuallyNot(beNil())
+                    expect(update?.oldValue).toEventually(equal(self.defaultValue))
+                    expect(update?.newValue).toEventually(equal(self.defaultValue))
+                }
+                #endif
+
                 then("remove observer on dispose") {
                     let key = DefaultsKey<Serializable?>("test", defaultValue: self.defaultValue)
 
@@ -455,6 +760,24 @@ extension DefaultsSerializableSpec where Serializable.T: Equatable, Serializable
                     expect(update?.oldValue).toEventually(beNil())
                     expect(update?.newValue).toEventually(beNil())
                 }
+
+                #if swift(>=5.1)
+                then("remove observer on dispose with dynamicMemberLookup") {
+                    self.keyStore.testOptionalValue = DefaultsKey<Serializable?>("test", defaultValue: self.defaultValue)
+
+                    var update: DefaultsObserver<Serializable?>.Update?
+                    let observer = defaults.observe.testOptionalValue { receivedUpdate in
+                        update = receivedUpdate
+                    }
+
+                    observer.dispose()
+                    defaults.testOptionalValue = self.customValue
+
+                    expect(update?.oldValue).toEventually(beNil())
+                    expect(update?.newValue).toEventually(beNil())
+                }
+                #endif
+
             }
 
             when("non-optional key") {
@@ -472,6 +795,22 @@ extension DefaultsSerializableSpec where Serializable.T: Equatable, Serializable
                     expect(update?.newValue).toEventually(equal(self.customValue))
                 }
 
+                #if swift(>=5.1)
+                then("receive updates with dynamicMemberLookup") {
+                    self.keyStore.testValue = DefaultsKey<Serializable>("test", defaultValue: self.defaultValue)
+
+                    var update: DefaultsObserver<Serializable>.Update?
+                    let observer = defaults.observe.testValue { receivedUpdate in
+                        update = receivedUpdate
+                    }
+
+                    defaults.testValue = self.customValue
+
+                    expect(update?.oldValue).toEventually(equal(self.defaultValue))
+                    expect(update?.newValue).toEventually(equal(self.customValue))
+                }
+                #endif
+
                 then("receives initial update") {
                     let key = DefaultsKey<Serializable>("test", defaultValue: self.defaultValue)
 
@@ -483,6 +822,20 @@ extension DefaultsSerializableSpec where Serializable.T: Equatable, Serializable
                     expect(update?.oldValue).toEventually(equal(self.defaultValue))
                     expect(update?.newValue).toEventually(equal(self.defaultValue))
                 }
+
+                #if swift(>=5.1)
+                then("receives initial update with dynamicMemberLookup") {
+                    self.keyStore.testValue = DefaultsKey<Serializable>("test", defaultValue: self.defaultValue)
+
+                    var update: DefaultsObserver<Serializable>.Update?
+                    let observer = defaults.observe.testValue([.initial, .old, .new]) { receivedUpdate in
+                        update = receivedUpdate
+                    }
+
+                    expect(update?.oldValue).toEventually(equal(self.defaultValue))
+                    expect(update?.newValue).toEventually(equal(self.defaultValue))
+                }
+                #endif
 
                 then("remove observer on dispose") {
                     let key = DefaultsKey<Serializable>("test", defaultValue: self.defaultValue)
@@ -498,6 +851,23 @@ extension DefaultsSerializableSpec where Serializable.T: Equatable, Serializable
                     expect(update?.oldValue).toEventually(beNil())
                     expect(update?.newValue).toEventually(beNil())
                 }
+
+                #if swift(>=5.1)
+                then("receives initial update with dynamicMemberLookup") {
+                    self.keyStore.testValue = DefaultsKey<Serializable>("test", defaultValue: self.defaultValue)
+
+                    var update: DefaultsObserver<Serializable>.Update?
+                    let observer = defaults.observe.testValue { receivedUpdate in
+                        update = receivedUpdate
+                    }
+
+                    observer.dispose()
+                    defaults.testValue = self.customValue
+
+                    expect(update?.oldValue).toEventually(beNil())
+                    expect(update?.newValue).toEventually(beNil())
+                }
+                #endif
             }
         }
         #endif

--- a/Tests/SwiftyUserDefaultsTests/TestHelpers/TestHelper.swift
+++ b/Tests/SwiftyUserDefaultsTests/TestHelpers/TestHelper.swift
@@ -116,3 +116,14 @@ struct FrogCustomSerializable: DefaultsSerializable, Equatable {
 
     let name: String
 }
+
+
+final class FrogKeyStore<Serializable: DefaultsSerializable & Equatable>: DefaultsKeyStoreType {
+
+    #if swift(>=5.1)
+    lazy var testValue: DefaultsKey<Serializable> = { fatalError("not initialized yet") }()
+    lazy var testArray: DefaultsKey<[Serializable]> = { fatalError("not initialized yet") }()
+    lazy var testOptionalValue: DefaultsKey<Serializable?> = { fatalError("not initialized yet") }()
+    lazy var testOptionalArray: DefaultsKey<[Serializable]?> = { fatalError("not initialized yet") }()
+    #endif
+}

--- a/Tests/SwiftyUserDefaultsTests/TestHelpers/TestHelper.swift
+++ b/Tests/SwiftyUserDefaultsTests/TestHelpers/TestHelper.swift
@@ -117,7 +117,6 @@ struct FrogCustomSerializable: DefaultsSerializable, Equatable {
     let name: String
 }
 
-
 final class FrogKeyStore<Serializable: DefaultsSerializable & Equatable>: DefaultsKeyStoreType {
 
     #if swift(>=5.1)


### PR DESCRIPTION
This PR has [KeyPath dynamicMemberLookup](https://github.com/apple/swift-evolution/blob/master/proposals/0252-keypath-dynamic-member-lookup.md) support in Swift 5.1!

Here is example usage:

```swift
extension DefaultsKeyStore {
    var launchCount: DefaultsKey<Int> {
        return .init("launchCount", defaultValue: 0) 
    }
}

func application(_ application: UIApplication, didFinish...) -> Bool {
    Defaults.launchCount += 1
    return true
}
```

I've add a `DefaultsAdapter` class to realize above usages because UserDefaults can't support `@dynamincMemberLookup` annotation.
In addition, I've defined conventional SwiftyUserDefaults interfaces to `DefaultsType`.
DefaultsAdapter is adapted DefaultsType, so those work as conventional SwiftyUserDefaults too.